### PR TITLE
SDK-1031: Prepare iOS v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGE LOG
 
-### Version 1.3.0 (September 7, 2021)
+### Version 1.3.0 (September 13, 2021)
 * Adds public methods for suspending, discarding & resuming InApp Notifications
 * Adds public methods to increment/decrement values set via User properties
 * Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()` methods

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - CleverTap-iOS-SDK (3.9.4):
+  - CleverTap-iOS-SDK (3.10.0):
     - SDWebImage (~> 5.1)
-  - clevertap_plugin (1.2.3):
-    - CleverTap-iOS-SDK (= 3.9.4)
+  - clevertap_plugin (1.3.0):
+    - CleverTap-iOS-SDK (= 3.10.0)
     - Flutter
   - Flutter (1.0.0)
   - SDWebImage (5.11.1):
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: 923e0a8829f4f8a16a8412f1e661d9b650d9633d
-  clevertap_plugin: 00a8c28a82aedd75a16d93143f4c6738dad326e4
+  CleverTap-iOS-SDK: 1e38a25eee5bdb3e525c5c8497504bc64b7d695d
+  clevertap_plugin: 5c2cb2747d4e3d8c8f5af171794752dfa81b6249
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.0

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -259,7 +259,7 @@ class _MyAppState extends State<MyApp> {
                     padding: const EdgeInsets.all(4.0),
                     child: ListTile(
                       title: Text("Profile increment value"),
-                      subtitle: Text("Increment value by 10"),
+                      subtitle: Text("Increment value by 15"),
                       onTap: incrementValue,
                     ),
                   ),
@@ -1235,13 +1235,13 @@ class _MyAppState extends State<MyApp> {
 
   void incrementValue() {
     var value = 15;
-    CleverTapPlugin.profileIncrementValue("props", value);
+    CleverTapPlugin.profileIncrementValue("score", value);
     showToast("check console for details");
   }
 
   void decrementValue() {
     var value = 10;
-    CleverTapPlugin.profileDecrementValue("props", value);
+    CleverTapPlugin.profileDecrementValue("score", value);
     showToast("check console for details");
   }
 

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -121,6 +121,8 @@ static NSDateFormatter *dateFormatter;
         [self profileGetCleverTapAttributionIdentifier:call withResult:result];
     else if ([@"profileGetCleverTapID" isEqualToString:call.method])
         [self profileGetCleverTapID:call withResult:result];
+    else if ([@"getCleverTapID" isEqualToString:call.method])
+        [self getCleverTapID:call withResult:result];
     else if ([@"profileGetProperty" isEqualToString:call.method])
         [self profileGetProperty:call withResult:result];
     else if ([@"profileRemoveValueForKey" isEqualToString:call.method])
@@ -405,6 +407,11 @@ static NSDateFormatter *dateFormatter;
     result([[CleverTap sharedInstance] profileGetCleverTapID]);
 }
 
+- (void)getCleverTapID:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    
+    result([[CleverTap sharedInstance] profileGetCleverTapID]);
+}
+
 - (void)profileGetProperty:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     
     result([[CleverTap sharedInstance] profileGet:call.arguments[@"propertyName"]]);
@@ -495,17 +502,20 @@ static NSDateFormatter *dateFormatter;
     result(res);
 }
 
-#pragma mark - InApp Controls
+#pragma mark - InApp Notification Controls
 
-- (void) suspendInAppNotifications {
+- (void)suspendInAppNotifications {
+    
     [[CleverTap sharedInstance] suspendInAppNotifications];
 }
 
-- (void) discardInAppNotifications {
+- (void)discardInAppNotifications {
+    
     [[CleverTap sharedInstance] discardInAppNotifications];
 }
 
-- (void) resumeInAppNotifications {
+- (void)resumeInAppNotifications {
+    
     [[CleverTap sharedInstance] resumeInAppNotifications];
 }
 

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -10,6 +10,7 @@
 #import "CleverTap+ProductConfig.h"
 #import "CleverTapPushNotificationDelegate.h"
 #import "CleverTapInAppNotificationDelegate.h"
+#import "CleverTap+InAppNotifications.h"
 
 @interface CleverTapPlugin () <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushNotificationDelegate>
 
@@ -134,6 +135,10 @@ static NSDateFormatter *dateFormatter;
         [self profileRemoveMultiValue:call withResult:result];
     else if ([@"profileRemoveMultiValues" isEqualToString:call.method])
         [self profileRemoveMultiValues:call withResult:result];
+    else if ([@"profileIncrementValue" isEqualToString:call.method])
+        [self profileIncrementValue:call withResult:result];
+    else if ([@"profileDecrementValue" isEqualToString:call.method])
+        [self profileDecrementValue:call withResult:result];
     else if ([@"pushInstallReferrer" isEqualToString:call.method])
         [self pushInstallReferrer:call withResult:result];
     else if ([@"sessionGetTimeElapsed" isEqualToString:call.method])
@@ -146,6 +151,12 @@ static NSDateFormatter *dateFormatter;
         [self sessionGetPreviousVisitTime:call withResult:result];
     else if ([@"sessionGetUTMDetails" isEqualToString:call.method])
         [self sessionGetUTMDetails:call withResult:result];
+    else if ([@"suspendInAppNotifications" isEqualToString:call.method])
+        [self suspendInAppNotifications];
+    else if ([@"discardInAppNotifications" isEqualToString:call.method])
+        [self discardInAppNotifications];
+    else if ([@"resumeInAppNotifications" isEqualToString:call.method])
+        [self resumeInAppNotifications];
     else if ([@"getInboxMessageCount" isEqualToString:call.method])
         [self getInboxMessageCount:call withResult:result];
     else if ([@"getInboxMessageUnreadCount" isEqualToString:call.method])
@@ -435,6 +446,18 @@ static NSDateFormatter *dateFormatter;
     result(nil);
 }
 
+- (void)profileIncrementValue:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    
+    [[CleverTap sharedInstance] profileIncrementValueBy:call.arguments[@"value"] forKey:call.arguments[@"key"]];
+    result(nil);
+}
+
+- (void)profileDecrementValue:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    
+    [[CleverTap sharedInstance] profileDecrementValueBy:call.arguments[@"value"] forKey:call.arguments[@"key"]];
+    result(nil);
+}
+
 - (void)pushInstallReferrer:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     
     [[CleverTap sharedInstance] pushInstallReferrerSource:call.arguments[@"source"] medium:call.arguments[@"medium"] campaign:call.arguments[@"campaign"]];
@@ -472,6 +495,19 @@ static NSDateFormatter *dateFormatter;
     result(res);
 }
 
+#pragma mark - InApp Controls
+
+- (void) suspendInAppNotifications {
+    [[CleverTap sharedInstance] suspendInAppNotifications];
+}
+
+- (void) discardInAppNotifications {
+    [[CleverTap sharedInstance] discardInAppNotifications];
+}
+
+- (void) resumeInAppNotifications {
+    [[CleverTap sharedInstance] resumeInAppNotifications];
+}
 
 #pragma mark - Inbox
 

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '1.2.3'
+  s.version                  = '1.3.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '3.9.4'
+  s.dependency               'CleverTap-iOS-SDK', '3.10.0'
   s.ios.deployment_target    = '9.0'
 end
 


### PR DESCRIPTION
- Adds InApp Notifications control methods
- Add Increment/ Decrement methods.
- Deprecates profileGetCleverTapID() and profileGetCleverTapAttributionIdentifier().
- Adds public method getCleverTapID() as an alternative to above-deprecated methods.
- Update CleverTap SDK version 3.10.0