### PR TITLE
chore(sdk-1268) Update .gitignore to exclude /example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .packages
 .idea/
 .DS_Store
+example/build
 example/android/app/google-services.json


### PR DESCRIPTION
Updated .gitignore to exclude build files under /example 