### PR TITLE
fix(SDK-2429): fix flutter module build failure issue in existing app

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    api 'com.clevertap.android:clevertap-android-sdk:4.6.3'
+    api 'com.clevertap.android:clevertap-android-sdk:4.6.6'
     compileOnly 'androidx.fragment:fragment:1.3.6'
     compileOnly 'androidx.core:core:1.3.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    implementation 'com.clevertap.android:clevertap-android-sdk:4.6.3'
-    implementation 'androidx.fragment:fragment:1.3.6'
-    implementation 'androidx.core:core:1.3.0'
+    api 'com.clevertap.android:clevertap-android-sdk:4.6.3'
+    compileOnly 'androidx.fragment:fragment:1.3.6'
+    compileOnly 'androidx.core:core:1.3.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_plugin'
-version '1.5.2'
+version '1.5.5'
 
 buildscript {
     repositories {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -56,7 +56,7 @@ flutter {
 dependencies {
     testImplementation 'junit:junit:4.13'
     //implementation fileTree('libs')
-    implementation 'com.clevertap.android:clevertap-android-sdk:4.6.6'
+    //implementation 'com.clevertap.android:clevertap-android-sdk:4.6.6'
     implementation "com.clevertap.android:push-templates:1.0.1"
     implementation 'com.google.firebase:firebase-messaging:21.0.0'
     implementation 'androidx.core:core:1.3.0'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     //implementation fileTree('libs')
     //implementation 'com.clevertap.android:clevertap-android-sdk:4.6.6'
-    implementation "com.clevertap.android:push-templates:1.0.1"
+    implementation "com.clevertap.android:push-templates:1.0.5"
     implementation 'com.google.firebase:firebase-messaging:21.0.0'
     implementation 'androidx.core:core:1.3.0'
     implementation 'androidx.fragment:fragment:1.3.6'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -56,7 +56,7 @@ flutter {
 dependencies {
     testImplementation 'junit:junit:4.13'
     //implementation fileTree('libs')
-    implementation 'com.clevertap.android:clevertap-android-sdk:4.6.3'
+    implementation 'com.clevertap.android:clevertap-android-sdk:4.6.6'
     implementation "com.clevertap.android:push-templates:1.0.1"
     implementation 'com.google.firebase:firebase-messaging:21.0.0'
     implementation 'androidx.core:core:1.3.0'


### PR DESCRIPTION
Add support in CleverTap Plugin to work as a flutter module in native apps (https://docs.flutter.dev/development/add-to-app)