### PR TITLE
SDK-2597 - Added Push Primer support in iOS

### DIFF
--- a/doc/PushPrimer.md
+++ b/doc/PushPrimer.md
@@ -2,7 +2,7 @@
 
 Push Primer allows you to enable runtime push permission for sending notifications from an app.
 
-Starting with the v2.0.0 release, CleverTap Flutter SDK supports Push primer for push notification runtime permission through local in-app.
+Starting with the v1.6.0 release, CleverTap Flutter SDK supports Push primer for push notification runtime permission through local in-app.
 
 For Push Primer, minimum supported version for iOS platform is 10.0 while android 13 for the android platform.
 

--- a/doc/PushPrimer.md
+++ b/doc/PushPrimer.md
@@ -1,0 +1,97 @@
+##  🔖 Overview
+
+Push Primer allows you to enable runtime push permission for sending notifications from an app.
+
+Starting with the v2.0.0 release, CleverTap Flutter SDK supports Push primer for push notification runtime permission through local in-app.
+
+For Push Primer, minimum supported version for iOS platform is 10.0 while android 13 for the android platform.
+
+### Push Primer using Half-Interstitial local In-app
+```Dart
+var pushPrimerJSON = {
+  'inAppType': 'half-interstitial',
+  'titleText': 'Get Notified',
+  'messageText': 'Please enable notifications on your device to use Push Notifications.',
+  'followDeviceOrientation': false,
+  'positiveBtnText': 'Allow',
+  'negativeBtnText': 'Cancel',
+  'fallbackToSettings': true,
+  'backgroundColor': '#FFFFFF',
+  'btnBorderColor': '#000000',
+  'titleTextColor': '#000000',
+  'messageTextColor': '#000000',
+  'btnTextColor': '#000000',
+  'btnBackgroundColor': '#FFFFFF',
+  'btnBorderRadius': '4',
+  'imageUrl': 'https://icons.iconarchive.com/icons/treetog/junior/64/camera-icon.png'
+};
+CleverTapPlugin.promptPushPrimer(pushPrimerJSON);
+```
+
+### Push Primer using Alert local In-app
+```Dart
+var pushPrimerJSON = {
+  'inAppType': 'alert',
+  'titleText': 'Get Notified',
+  'messageText': 'Enable Notification permission',
+  'followDeviceOrientation': true,
+  'positiveBtnText': 'Allow',
+  'negativeBtnText': 'Cancel',
+  'fallbackToSettings': true
+};
+CleverTapPlugin.promptPushPrimer(pushPrimerJSON);
+```
+
+### Prompt the Notification Permission Dialog (without push primer)
+It takes boolean as a parameter. If the value passed is true and permission is denied then we fallback to app’s notification settings. If false then we just give the callback saying permission is denied.
+
+```Dart
+var fallbackToSettings = false;
+CleverTapPlugin.promptForPushNotification(fallbackToSettings);
+```
+
+### Get the Push notification permission status
+Returns the status of the push notification permission.
+
+```Dart
+bool? isPushPermissionEnabled = await CleverTapPlugin.getPushNotificationPermissionStatus();
+if (isPushPermissionEnabled == null) return;
+
+if (!isPushPermissionEnabled) {
+  // call Push Primer here.
+} else {
+  print("Push Permission is already enabled.");
+}
+```
+
+###  Description of the pushPrimerJSON Object passed inside the promptPushPrimer method
+
+Key Name| Parameters | Description | Required
+:---:|:---:|:---:|:---
+`inAppType` | "half-interstitial" or "alert" | Accepts only half-interstitial & alert type to display the local in-app | Required
+`titleText` | String | Sets the title of the local in-app | Required
+`messageText` | String | Sets the subtitle of the local in-app | Required
+`followDeviceOrientation` | true or false | If true then the local InApp is shown for both portrait and landscape. If it sets false then local InApp only displays for portrait mode | Required
+`positiveBtnText` | String | Sets the text of the positive button | Required
+`negativeBtnText` | String | Sets the text of the negative button | Required
+`fallbackToSettings` | true or false | If true and the permission is denied then we fallback to app’s notification settings, if it’s false then we just give the callback saying permission is denied. | Optional
+`backgroundColor` | Accepts Hex color as String | Sets the background color of the local in-app | Optional
+`btnBorderColor` | Accepts Hex color as String | Sets the border color of both positive/negative buttons | Optional
+`titleTextColor` | Accepts Hex color as String | Sets the title color of the local in-app | Optional
+`messageTextColor` | Accepts Hex color as String | Sets the sub-title color of the local in-app | Optional
+`btnTextColor` | Accepts Hex color as String | Sets the color of text for both positive/negative buttons | Optional
+`btnBackgroundColor` | Accepts Hex color as String | Sets the background color for both positive/negative buttons | Optional
+`btnBorderRadius` | String | Sets the radius for both positive/negative buttons. Default radius is “2” if not set | Optional
+`imageUrl` | String | Sets the background image url | Optional
+
+
+###  Available Callback for Push Primer
+Based on notification permission grant/deny, CleverTap Flutter SDK provides a callback with the permission accepted status.
+
+```Dart
+_clevertapPlugin.setCleverTapPushPermissionResponseReceivedHandler(pushPermissionResponseReceived);
+
+void pushPermissionResponseReceived(bool accepted) {
+  print("Push Permission response called ---> accepted = " + (accepted ? "true" : "false"));
+}
+```

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -457,6 +457,11 @@ CleverTapPlugin.setOffline(false);
 CleverTapPlugin.setOffline(true);
 ```
 
+-----------
+
+## Push primer for notification Permission (Android and iOS)
+Follow the [Push Primer integration doc](PushPrimer.md).
+
 
 ### For more information,
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - CleverTap-iOS-SDK (4.1.4):
-    - SDWebImage (~> 5.1)
-  - clevertap_plugin (1.5.4):
-    - CleverTap-iOS-SDK (= 4.1.4)
+  - CleverTap-iOS-SDK (4.2.0):
+    - SDWebImage (~> 5.11)
+  - clevertap_plugin (1.5.5):
+    - CleverTap-iOS-SDK (= 4.2.0)
     - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.13.4):
-    - SDWebImage/Core (= 5.13.4)
-  - SDWebImage/Core (5.13.4)
+  - SDWebImage (5.15.0):
+    - SDWebImage/Core (= 5.15.0)
+  - SDWebImage/Core (5.15.0)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: ec4a641fcec7255759252eb91ff3ee603bd5e5e3
-  clevertap_plugin: 929e3b76940daf4a2dbacfd5130708bd249da857
+  CleverTap-iOS-SDK: 124ee0f4bd90c5ffa213b2da05f81496d7339015
+  clevertap_plugin: 302276f4ce17fe8c40c4db6c8f0cac080dcec259
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
+  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,6 +67,7 @@ class _MyAppState extends State<MyApp> {
         .setCleverTapProductConfigFetchedHandler(productConfigFetched);
     _clevertapPlugin
         .setCleverTapProductConfigActivatedHandler(productConfigActivated);
+    _clevertapPlugin.setCleverTapPushPermissionResponseReceivedHandler(pushPermissionResponseReceived);
   }
 
   void inAppNotificationDismissed(Map<String, dynamic> map) {
@@ -180,6 +181,10 @@ class _MyAppState extends State<MyApp> {
       var data = jsonEncode(map);
       print("on Push Click Payload = " + data.toString());
     });
+  }
+
+  void pushPermissionResponseReceived(bool accepted) {
+    print("Push Permission response called ---> accepted = " + (accepted ? "true" : "false"));
   }
 
   @override
@@ -1068,6 +1073,45 @@ class _MyAppState extends State<MyApp> {
                     ),
                   ),
                 ),
+                Card(
+                  color: Colors.lightBlueAccent,
+                  child: Padding(
+                    padding: const EdgeInsets.all(0.0),
+                    child: ListTile(
+                      title: Text("Push Primer"),
+                    ),
+                  ),
+                ),
+                Card(
+                  color: Colors.grey.shade300,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: ListTile(
+                      title: Text("Prompt for Push Notification"),
+                      onTap: promptForPushNotification,
+                    ),
+                  ),
+                ),
+                Card(
+                  color: Colors.grey.shade300,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: ListTile(
+                      title: Text("Local Half Interstitial Push Primer"),
+                      onTap: localHalfInterstitialPushPrimer,
+                    ),
+                  ),
+                ),
+                Card(
+                  color: Colors.grey.shade300,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: ListTile(
+                      title: Text("Local Alert Push Primer"),
+                      onTap: localAlertPushPrimer,
+                    ),
+                  ),
+                ),
               ],
             )),
       ),
@@ -1814,5 +1858,58 @@ class _MyAppState extends State<MyApp> {
   void fetchAndActivate() {
     CleverTapPlugin.fetchAndActivate();
     showToast("check console for logs");
+  }
+
+  void promptForPushNotification() {
+    var fallbackToSettings = false;
+    CleverTapPlugin.promptForPushNotification(fallbackToSettings);
+    showToast("Prompt Push Permission");
+  }
+
+  void localHalfInterstitialPushPrimer() {
+    var pushPrimerJSON = {
+      'inAppType': 'half-interstitial',
+      'titleText': 'Get Notified',
+      'messageText': 'Please enable notifications on your device to use Push Notifications.',
+      'followDeviceOrientation': false,
+      'positiveBtnText': 'Allow',
+      'negativeBtnText': 'Cancel',
+      'fallbackToSettings': true,
+      'backgroundColor': '#FFFFFF',
+      'btnBorderColor': '#000000',
+      'titleTextColor': '#000000',
+      'messageTextColor': '#000000',
+      'btnTextColor': '#000000',
+      'btnBackgroundColor': '#FFFFFF',
+      'btnBorderRadius': '4',
+      'imageUrl': 'https://icons.iconarchive.com/icons/treetog/junior/64/camera-icon.png'
+    };
+    CleverTapPlugin.promptPushPrimer(pushPrimerJSON);
+    showToast("Half-Interstitial Push Primer");
+  }
+
+  void localAlertPushPrimer() {
+    this.setState(() async {
+      bool? isPushPermissionEnabled = await CleverTapPlugin.getPushNotificationPermissionStatus();
+      if (isPushPermissionEnabled == null) return;
+
+      // Check Push Permission status and then call `promptPushPrimer` if not enabled.
+      if (!isPushPermissionEnabled) {
+        var pushPrimerJSON = {
+          'inAppType': 'alert',
+          'titleText': 'Get Notified',
+          'messageText': 'Enable Notification permission',
+          'followDeviceOrientation': true,
+          'positiveBtnText': 'Allow',
+          'negativeBtnText': 'Cancel',
+          'fallbackToSettings': true
+        };
+        CleverTapPlugin.promptPushPrimer(pushPrimerJSON);
+        showToast("Alert Push Primer");
+      } else {
+        print("Push Permission is already enabled.");
+      }
+    });
+
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.5.5"
   clock:
     dependency: transitive
     description:

--- a/ios/Classes/CleverTapPlugin.h
+++ b/ios/Classes/CleverTapPlugin.h
@@ -14,6 +14,7 @@ static NSString *const kCleverTapProductConfigActivated           = @"productCon
 static NSString *const kCleverTapProductConfigInitialized         = @"productConfigInitialized";
 static NSString *const kCleverTapFeatureFlagsUpdated              = @"featureFlagsUpdated";
 static NSString *const kCleverTapPushNotificationClicked          = @"pushClickedPayloadReceived";
+static NSString *const kCleverTapPushPermissionResponseReceived   = @"pushPermissionResponseReceived";
 
 @interface CleverTapPlugin : NSObject <FlutterPlugin>
 

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -11,8 +11,10 @@
 #import "CleverTapPushNotificationDelegate.h"
 #import "CleverTapInAppNotificationDelegate.h"
 #import "CleverTap+InAppNotifications.h"
+#import "CleverTap+PushPermission.h"
+#import "CTLocalInApp.h"
 
-@interface CleverTapPlugin () <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushNotificationDelegate>
+@interface CleverTapPlugin () <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushNotificationDelegate, CleverTapPushPermissionDelegate>
 
 @property (strong, nonatomic) FlutterMethodChannel *channel;
 
@@ -57,6 +59,7 @@ static NSDateFormatter *dateFormatter;
         [[clevertap featureFlags] setDelegate:self];
         [clevertap setPushNotificationDelegate:self];
         [clevertap setLibrary:@"Flutter"];
+        [clevertap setPushPermissionDelegate:self];
         [self addObservers];
     }
     return self;
@@ -237,6 +240,12 @@ static NSDateFormatter *dateFormatter;
         result(nil);
     else if ([@"setHuaweiPushToken" isEqualToString:call.method])
         result(nil);
+    else if ([@"promptPushPrimer" isEqualToString:call.method])
+        [self promptPushPrimer:call withResult:result];
+    else if ([@"promptForPushNotification" isEqualToString:call.method])
+        [self promptForPushNotification:call withResult:result];
+    else if ([@"getPushNotificationPermissionStatus" isEqualToString:call.method])
+        [self getPushNotificationPermissionStatus:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -925,6 +934,11 @@ static NSDateFormatter *dateFormatter;
     [self.channel invokeMethod:notification.name arguments:notification.userInfo];
 }
 
+- (void)emitEventPushPermissionResponse:(NSNotification *)notification {
+    // Passed boolean value of `accepted` directly.
+    [self.channel invokeMethod:notification.name arguments:notification.userInfo[@"accepted"]];
+}
+
 - (void)addObservers {
     
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -995,6 +1009,11 @@ static NSDateFormatter *dateFormatter;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(emitEventInternal:)
                                                  name:kCleverTapPushNotificationClicked
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(emitEventPushPermissionResponse:)
+                                                 name:kCleverTapPushPermissionResponseReceived
                                                object:nil];
 }
 
@@ -1126,6 +1145,113 @@ static NSDateFormatter *dateFormatter;
     
     [[CleverTap sharedInstance] recordNotificationClickedEventWithData:call.arguments[@"notificationData"]];
     result(nil);
+}
+
+#pragma mark - Push Primer
+
+- (void)promptForPushNotification:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL isFallbackToSettings = [call.arguments boolValue];
+    [[CleverTap sharedInstance] promptForPushPermission: isFallbackToSettings];
+}
+
+- (void)promptPushPrimer:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSDictionary *json = call.arguments;
+    BOOL isJSONInvalid = [self validatePushPrimerRequiredSettings:json];
+    if (!isJSONInvalid) {
+        CTLocalInApp *localInAppBuilder = [self buildLocalInApp:json];
+        [[CleverTap sharedInstance] promptPushPrimer:localInAppBuilder.getLocalInAppSettings];
+    } else {
+        NSLog(@"CleverTapFlutter: Invalid Push Primer JSON received");
+    }
+}
+
+- (void)getPushNotificationPermissionStatus:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [[CleverTap sharedInstance] getNotificationPermissionStatusWithCompletionHandler:^(UNAuthorizationStatus status) {
+        BOOL isPushEnabled = YES;
+        if (status == UNAuthorizationStatusNotDetermined || status == UNAuthorizationStatusDenied) {
+            isPushEnabled = NO;
+        }
+        result(@(isPushEnabled));
+    }];
+}
+
+#pragma mark - CleverTapPushPermissionDelegate
+
+- (void)onPushPermissionResponse:(BOOL)accepted {
+    NSMutableDictionary *body = [NSMutableDictionary new];
+    body[@"accepted"] = [NSNumber numberWithBool:accepted];
+    [self postNotificationWithName:kCleverTapPushPermissionResponseReceived andBody:body];
+}
+
+- (BOOL)validatePushPrimerRequiredSettings:(NSDictionary *)json {
+    // Returns YES if any required key is not present or not of required type.
+    BOOL isJSONFormatInvalid = NO;
+    if (json[@"inAppType"] != nil) {
+        if (![json[@"inAppType"]  isEqual:@"half-interstitial"] && ![json[@"inAppType"]  isEqual:@"alert"]) {
+            isJSONFormatInvalid = YES;
+        }
+    } else {
+        isJSONFormatInvalid = YES;
+    }
+    if (json[@"titleText"] == nil || ![json[@"titleText"] isKindOfClass:[NSString class]]) {
+        isJSONFormatInvalid = YES;
+    }
+    if (json[@"messageText"] == nil || ![json[@"messageText"] isKindOfClass:[NSString class]]) {
+        isJSONFormatInvalid = YES;
+    }
+    if (json[@"followDeviceOrientation"] == nil) {
+        isJSONFormatInvalid = YES;
+    }
+    if (json[@"positiveBtnText"] == nil || ![json[@"positiveBtnText"] isKindOfClass:[NSString class]]) {
+        isJSONFormatInvalid = YES;
+    }
+    if (json[@"negativeBtnText"] == nil || ![json[@"negativeBtnText"] isKindOfClass:[NSString class]]) {
+        isJSONFormatInvalid = YES;
+    }
+    return isJSONFormatInvalid;
+}
+
+- (CTLocalInApp *)buildLocalInApp:(NSDictionary *)json {
+    CTLocalInAppType inAppType;
+    if ([json[@"inAppType"]  isEqual:@"half-interstitial"]) {
+        inAppType = HALF_INTERSTITIAL;
+    } else {
+        inAppType = ALERT;
+    }
+    CTLocalInApp *localInAppBuilder = [[CTLocalInApp alloc] initWithInAppType:inAppType
+                                                                    titleText:json[@"titleText"]
+                                                                  messageText:json[@"messageText"]
+                                                      followDeviceOrientation:[json[@"followDeviceOrientation"] boolValue]
+                                                              positiveBtnText:json[@"positiveBtnText"]
+                                                              negativeBtnText:json[@"negativeBtnText"]];
+    if (json[@"fallbackToSettings"] != nil) {
+        [localInAppBuilder setFallbackToSettings:[json[@"fallbackToSettings"] boolValue]];
+    }
+    if (json[@"backgroundColor"] != nil && [json[@"backgroundColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setBackgroundColor:json[@"backgroundColor"]];
+    }
+    if (json[@"btnBorderColor"] != nil && [json[@"btnBorderColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setBtnBorderColor:json[@"btnBorderColor"]];
+    }
+    if (json[@"titleTextColor"] != nil && [json[@"titleTextColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setTitleTextColor:json[@"titleTextColor"]];
+    }
+    if (json[@"messageTextColor"] != nil && [json[@"messageTextColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setMessageTextColor:json[@"messageTextColor"]];
+    }
+    if (json[@"btnTextColor"] != nil && [json[@"btnTextColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setBtnTextColor:json[@"btnTextColor"]];
+    }
+    if (json[@"btnBackgroundColor"] != nil && [json[@"btnBackgroundColor"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setBtnBackgroundColor:json[@"btnBackgroundColor"]];
+    }
+    if (json[@"btnBorderRadius"] != nil && [json[@"btnBorderRadius"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setBtnBorderRadius:json[@"btnBorderRadius"]];
+    }
+    if (json[@"imageUrl"] != nil && [json[@"imageUrl"] isKindOfClass:[NSString class]]) {
+        [localInAppBuilder setImageUrl:json[@"imageUrl"]];
+    }
+    return localInAppBuilder;
 }
 
 @end

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '4.1.4'
+  s.dependency               'CleverTap-iOS-SDK', '4.2.0'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -22,6 +22,7 @@ typedef void CleverTapProductConfigActivatedHandler();
 typedef void CleverTapPushAmpPayloadReceivedHandler(Map<String, dynamic> map);
 typedef void CleverTapPushClickedPayloadReceivedHandler(
     Map<String, dynamic> map);
+typedef void CleverTapPushPermissionResponseReceivedHandler(bool accepted);
 
 class CleverTapPlugin {
   late CleverTapInAppNotificationDismissedHandler
@@ -50,6 +51,7 @@ class CleverTapPlugin {
       cleverTapPushAmpPayloadReceivedHandler;
   late CleverTapPushClickedPayloadReceivedHandler
       cleverTapPushClickedPayloadReceivedHandler;
+  late CleverTapPushPermissionResponseReceivedHandler cleverTapPushPermissionResponseReceivedHandler;
 
   static const MethodChannel _channel = const MethodChannel('clevertap_plugin');
 
@@ -122,6 +124,10 @@ class CleverTapPlugin {
         Map<dynamic, dynamic> args = call.arguments;
         cleverTapPushClickedPayloadReceivedHandler(
             args.cast<String, dynamic>());
+        break;
+      case "pushPermissionResponseReceived":
+        bool accepted = call.arguments;
+        cleverTapPushPermissionResponseReceivedHandler(accepted);
         break;
     }
   }
@@ -199,6 +205,11 @@ class CleverTapPlugin {
   void setCleverTapPushClickedPayloadReceivedHandler(
           CleverTapPushClickedPayloadReceivedHandler handler) =>
       cleverTapPushClickedPayloadReceivedHandler = handler;
+
+  /// Define a method to handle Push permission response
+  void setCleverTapPushPermissionResponseReceivedHandler(
+          CleverTapPushPermissionResponseReceivedHandler handler) =>
+      cleverTapPushPermissionResponseReceivedHandler = handler;
 
   /// Sets debug level to show logs on Android Studio/Xcode console
   static Future<void> setDebugLevel(int value) async {
@@ -801,5 +812,21 @@ class CleverTapPlugin {
 
   static String getCleverTapDate(DateTime dateTime) {
     return '\$D_' + dateTime.millisecondsSinceEpoch.toString();
+  }
+
+  // Push Primer
+  ///Creates a push primer asking user to enable push notification.
+  static Future<void> promptPushPrimer(Map<String, dynamic> pushPrimerJSON) async {
+    return await _channel.invokeMethod('promptPushPrimer', pushPrimerJSON);
+  }
+
+  ///Directly calls OS hard dialog for requesting push permission.
+  static Future<void> promptForPushNotification(bool fallbackToSettings) async {
+    return await _channel.invokeMethod('promptForPushNotification', fallbackToSettings);
+  }
+
+  ///Returns true if push permission is enabled.
+  static Future<bool?> getPushNotificationPermissionStatus() async {
+    return await _channel.invokeMethod('getPushNotificationPermissionStatus', {});
   }
 }


### PR DESCRIPTION
- Added below new public APIs to support CleverTap iOS SDK v4.2.0 and Push Primer:
	- promptPushPrimer(Map<String, dynamic> pushPrimerJSON)
	- promptForPushNotification(bool fallbackToSettings)
	- getPushNotificationPermissionStatus()
- Added `CleverTapPushPermissionResponseReceivedHandler` to handle push permission response with a boolean argument.