### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGE LOG
 
+### Version 1.6.1 (April 4, 2023)
+* Fixed compilation errors in Xcode 14.3+ in iOS.
+* Streamlined the argument of `onDisplayUnitsLoaded` callback method in iOS to directly pass display unit array.
+* Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
+
 ### Version 1.6.0 (February 14, 2023)
 * Adds below new public APIs to support [CleverTap Android SDK v4.7.4](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-474-january-27-2023) and [CleverTap iOS SDK v4.2.0](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-420-december-13-2022)
     - `getPushNotificationPermissionStatus()`, `promptPushPrimer(object)`, `promptForPushNotification(boolean)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Version 1.6.0 (February 14, 2023)
 * Adds below new public APIs to support [CleverTap Android SDK v4.7.4](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-474-january-27-2023) and [CleverTap iOS SDK v4.2.0](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-420-december-13-2022)
-    - `isPushPermissionGranted()`, `promptPushPrimer(object)`, `promptForPushPermission(boolean)`
-* Adds push permission callback method which returns true/false after user allow/deny the notification permission.
-* Adds `onShow(CTInAppNotification)` callback for `InAppNotificationListener` - Only for Android.
+    - `getPushNotificationPermissionStatus()`, `promptPushPrimer(object)`, `promptForPushNotification(boolean)`
+* Adds push permission callback method `setCleverTapPushPermissionResponseReceivedHandler` which returns true/false after user allows/denies the notification permission.
+* Adds `setCleverTapInAppNotificationShowHandler` to handle InApp notification shown - Only for Android.
+* Streamlined the format of native display payload across Android and iOS.
+* Fixes the FCM Plugin's [onBackgroundMessage handler bug](https://github.com/CleverTap/clevertap-flutter/commit/8db6f34eec83e7f14990359f88c65a50e966acb3) which was breaking the CleverTap Plugin's platform channel for sending method calls from Android.
 
 ### Version 1.5.5 (January 23, 2023)
 * Adds fix for closing App Inbox controller when deeplink is present in iOS.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 1.6.0
+clevertap_plugin: 1.6.1
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_plugin'
-version '1.5.5'
+version '1.6.0'
 
 buildscript {
     repositories {

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -311,8 +311,7 @@ CleverTapPlugin.createNotification(data);
 
 ```Dart
 void onDisplayUnitsLoaded(List<dynamic> displayUnits) {
-    this.setState(() async {
-      List displayUnits = await CleverTapPlugin.getAllDisplayUnits();
+    this.setState(() {
       print("Display Units = " + displayUnits.toString());
    });
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - CleverTap-iOS-SDK (4.2.0):
+  - CleverTap-iOS-SDK (4.2.2):
     - SDWebImage (~> 5.11)
-  - clevertap_plugin (1.6.0):
-    - CleverTap-iOS-SDK (= 4.2.0)
+  - clevertap_plugin (1.6.1):
+    - CleverTap-iOS-SDK (= 4.2.2)
     - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.15.2):
-    - SDWebImage/Core (= 5.15.2)
-  - SDWebImage/Core (5.15.2)
+  - SDWebImage (5.15.5):
+    - SDWebImage/Core (= 5.15.5)
+  - SDWebImage/Core (5.15.5)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: 124ee0f4bd90c5ffa213b2da05f81496d7339015
-  clevertap_plugin: bdd8ed2df3af7bc0039b266656eb188e42426099
+  CleverTap-iOS-SDK: 36c21b8a671d87a0f9c7b389b339d02528bbe4d7
+  clevertap_plugin: ad23b6b75e86e2b1f8bac7afdfc3dbefa5d0b913
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  SDWebImage: 8ab87d4b3e5cc4927bd47f78db6ceb0b94442577
+  SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,20 +1,13 @@
 PODS:
-<<<<<<< HEAD
   - CleverTap-iOS-SDK (4.2.0):
     - SDWebImage (~> 5.11)
-  - clevertap_plugin (1.5.5):
+  - clevertap_plugin (1.6.0):
     - CleverTap-iOS-SDK (= 4.2.0)
-=======
-  - CleverTap-iOS-SDK (4.1.4):
-    - SDWebImage (~> 5.1)
-  - clevertap_plugin (1.5.5):
-    - CleverTap-iOS-SDK (= 4.1.4)
->>>>>>> f45643b4551c08c3a0f9e1222a598225e65828ba
     - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.15.0):
-    - SDWebImage/Core (= 5.15.0)
-  - SDWebImage/Core (5.15.0)
+  - SDWebImage (5.15.2):
+    - SDWebImage/Core (= 5.15.2)
+  - SDWebImage/Core (5.15.2)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -32,15 +25,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-<<<<<<< HEAD
   CleverTap-iOS-SDK: 124ee0f4bd90c5ffa213b2da05f81496d7339015
-  clevertap_plugin: 302276f4ce17fe8c40c4db6c8f0cac080dcec259
-=======
-  CleverTap-iOS-SDK: ec4a641fcec7255759252eb91ff3ee603bd5e5e3
-  clevertap_plugin: fef4b68c2ee1a665ae99c7063c2d0eb62eac8d3c
->>>>>>> f45643b4551c08c3a0f9e1222a598225e65828ba
+  clevertap_plugin: bdd8ed2df3af7bc0039b266656eb188e42426099
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
+  SDWebImage: 8ab87d4b3e5cc4927bd47f78db6ceb0b94442577
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -138,8 +138,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void onDisplayUnitsLoaded(List<dynamic>? displayUnits) {
-    this.setState(() async {
-      List? displayUnits = await CleverTapPlugin.getAllDisplayUnits();
+    this.setState(() {
       print("Display Units = " + displayUnits.toString());
     });
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.6.0"
+    version: "1.6.1"
   clock:
     dependency: transitive
     description:

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -940,6 +940,11 @@ static NSDateFormatter *dateFormatter;
     [self.nativeToDartMethodChannel invokeMethod:notification.name arguments:notification.userInfo[@"accepted"]];
 }
 
+- (void)emitEventDisplayUnitsLoaded:(NSNotification *)notification {
+    // Passed CleverTapDisplayUnit Array directly.
+    [self.nativeToDartMethodChannel invokeMethod:notification.name arguments:notification.userInfo[@"adUnits"]];
+}
+
 - (void)addObservers {
     
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -968,7 +973,7 @@ static NSDateFormatter *dateFormatter;
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(emitEventInternal:)
+                                             selector:@selector(emitEventDisplayUnitsLoaded:)
                                                  name:kCleverTapDisplayUnitsLoaded
                                                object:nil];
     

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '1.5.5'
+  s.version                  = '1.6.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '1.6.0'
+  s.version                  = '1.6.1'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '4.2.0'
+  s.dependency               'CleverTap-iOS-SDK', '4.2.2'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
- Fixed compilation errors in Xcode 14.3+ in iOS.
- Streamlined the argument of `onDisplayUnitsLoaded` callback method in iOS to directly pass display unit array.
- Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)