### PR TITLE
[SDK-2852]: Support Core Android v4.6.9 and Core iOS v4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ### Version 1.5.6 (April 5, 2023)
 #### Added
+* Adds the new public API `dismissInbox()` to dismiss the App Inbox.
 * Supports [CleverTap Android SDK v4.6.9](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-469-march-31-2023)
 * Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
 
 #### Changes
 * **[Breaking change to the signature of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
   It is changed from `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data)` to `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data, int contentPageIndex, int buttonIndex)`. The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the `contentPageIndex` value is always 0, as they only have one page of content. The `buttonIndex` corresponds to the the App Inbox button clicked (0, 1, or 2). A value of -1 in `buttonIndex` field indicates the entire App Inbox Item is clicked.
-
 * **[Behavioral change of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
   Previously, the callback was raised when the App Inbox Item is clicked. Now, it is also raised when the App Inbox button is clicked besides the item click.
+* Fixed compilation errors in Xcode 14.3+ in iOS.
+* Streamlined the argument of `onDisplayUnitsLoaded` callback method in iOS to directly pass display unit array.
 
 ### Version 1.5.5 (January 23, 2023)
 * Adds fix for closing App Inbox controller when deeplink is present in iOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Supports [CleverTap Android SDK v4.6.9](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-469-march-31-2023)
 * Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
 * Adds the new public API `dismissInbox()` to dismiss the App Inbox.
+* **Note**: This release is being done for Android 12 targeted users.
+
 
 #### Changed
 * **[Breaking change to the signature of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## CHANGE LOG
 
+### Version 1.5.6 (April 5, 2023)
+#### Added
+* Supports [CleverTap Android SDK v4.6.9](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-469-march-31-2023)
+* Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
+
+#### Changes
+* **[Breaking change to the signature of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
+  It is changed from `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data)` to `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data, int contentPageIndex, int buttonIndex)`. The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the `contentPageIndex` value is always 0, as they only have one page of content. The `buttonIndex` corresponds to the the App Inbox button clicked (0, 1, or 2). A value of -1 in `buttonIndex` field indicates the entire App Inbox Item is clicked.
+
+* **[Behavioral change of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
+  Previously, the callback was raised when the App Inbox Item is clicked. Now, it is also raised when the App Inbox button is clicked besides the item click.
+
 ### Version 1.5.5 (January 23, 2023)
 * Adds fix for closing App Inbox controller when deeplink is present in iOS.
 * Supports [add-to-app](https://docs.flutter.dev/development/add-to-app) feature for Android platform to embed the CleverTap plugin in a flutter module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,22 @@
 
 ### Version 1.5.6 (April 5, 2023)
 #### Added
-* Adds the new public API `dismissInbox()` to dismiss the App Inbox.
 * Supports [CleverTap Android SDK v4.6.9](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-469-march-31-2023)
 * Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
+* Adds the new public API `dismissInbox()` to dismiss the App Inbox.
 
-#### Changes
+#### Changed
 * **[Breaking change to the signature of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
   It is changed from `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data)` to `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data, int contentPageIndex, int buttonIndex)`. The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the `contentPageIndex` value is always 0, as they only have one page of content. The `buttonIndex` corresponds to the the App Inbox button clicked (0, 1, or 2). A value of -1 in `buttonIndex` field indicates the entire App Inbox Item is clicked.
 * **[Behavioral change of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
   Previously, the callback was raised when the App Inbox Item is clicked. Now, it is also raised when the App Inbox button is clicked besides the item click.
-* Fixed compilation errors in Xcode 14.3+ in iOS.
-* Streamlined the argument of `onDisplayUnitsLoaded` callback method in iOS to directly pass display unit array.
+* **[Native Display parity changes]**:
+  - Streamlines the format of native display payload across Android and iOS.
+  - Streamlines the argument of `onDisplayUnitsLoaded` callback method in iOS to pass the list of displayUnits.
+
+#### Fixed
+* Fixes the FCM Plugin's [onBackgroundMessage handler bug](https://github.com/CleverTap/clevertap-flutter/commit/8db6f34eec83e7f14990359f88c65a50e966acb3) which was breaking the CleverTap Plugin's platform channel for sending method calls from Android to Dart platform.
+* Fixes the Xcode 14.3+ compilation errors in iOS.
 
 ### Version 1.5.5 (January 23, 2023)
 * Adds fix for closing App Inbox controller when deeplink is present in iOS.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 1.5.5
+clevertap_plugin: 1.5.6
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_plugin'
-version '1.5.5'
+version '1.5.6'
 
 buildscript {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    api 'com.clevertap.android:clevertap-android-sdk:4.6.8'
+    api 'com.clevertap.android:clevertap-android-sdk:4.6.9'
     compileOnly 'androidx.fragment:fragment:1.3.6'
     compileOnly 'androidx.core:core:1.3.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    api 'com.clevertap.android:clevertap-android-sdk:4.6.6'
+    api 'com.clevertap.android:clevertap-android-sdk:4.6.8'
     compileOnly 'androidx.fragment:fragment:1.3.6'
     compileOnly 'androidx.core:core:1.3.0'
 }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -173,8 +173,12 @@ public class CleverTapPlugin implements ActivityAware,
     }
 
     @Override
-    public void onInboxItemClicked(final CTInboxMessage message) {
-        invokeMethodOnUiThread("onInboxMessageClick", Utils.jsonObjectToMap(message.getData()));
+    public void onInboxItemClicked(CTInboxMessage message, int itemIndex, int buttonIndex) {
+        Map<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("data", Utils.jsonObjectToMap(message.getData()));
+        payloadMap.put("itemIndex", itemIndex);
+        payloadMap.put("buttonIndex", buttonIndex);
+        invokeMethodOnUiThread("onInboxMessageClick", payloadMap);
     }
 
     @Override
@@ -432,6 +436,10 @@ public class CleverTapPlugin implements ActivityAware,
             }
             case "showInbox": {
                 showInbox(call, result);
+                break;
+            }
+            case "dismissInbox": {
+                dismissInbox(result);
                 break;
             }
             case "getInboxMessageCount": {
@@ -1468,6 +1476,15 @@ public class CleverTapPlugin implements ActivityAware,
         styleConfig = Utils.jsonToStyleConfig(styleConfigJson);
         if (isCleverTapNotNull(cleverTapAPI)) {
             cleverTapAPI.showAppInbox(styleConfig);
+            result.success(null);
+        } else {
+            result.error(TAG, ERROR_MSG, null);
+        }
+    }
+
+    private void dismissInbox(Result result) {
+        if (isCleverTapNotNull(cleverTapAPI)) {
+            cleverTapAPI.dismissAppInbox();
             result.success(null);
         } else {
             result.error(TAG, ERROR_MSG, null);

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -173,10 +173,10 @@ public class CleverTapPlugin implements ActivityAware,
     }
 
     @Override
-    public void onInboxItemClicked(CTInboxMessage message, int itemIndex, int buttonIndex) {
+    public void onInboxItemClicked(CTInboxMessage message, int contentPageIndex, int buttonIndex) {
         Map<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("data", Utils.jsonToMapWithRecursion(message.getData()));
-        payloadMap.put("itemIndex", itemIndex);
+        payloadMap.put("contentPageIndex", contentPageIndex);
         payloadMap.put("buttonIndex", buttonIndex);
         invokeMethodOnUiThread("onInboxMessageClick", payloadMap);
     }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -175,7 +175,7 @@ public class CleverTapPlugin implements ActivityAware,
     @Override
     public void onInboxItemClicked(CTInboxMessage message, int itemIndex, int buttonIndex) {
         Map<String, Object> payloadMap = new HashMap<>();
-        payloadMap.put("data", Utils.jsonObjectToMap(message.getData()));
+        payloadMap.put("data", Utils.jsonToMapWithRecursion(message.getData()));
         payloadMap.put("itemIndex", itemIndex);
         payloadMap.put("buttonIndex", buttonIndex);
         invokeMethodOnUiThread("onInboxMessageClick", payloadMap);

--- a/android/src/main/java/com/clevertap/clevertap_plugin/Utils.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/Utils.java
@@ -67,7 +67,7 @@ public class Utils {
         ArrayList<Map<String, Object>> displayUnitList = new ArrayList<>();
         if (units != null) {
             for (CleverTapDisplayUnit unit : units) {
-                displayUnitList.add(Utils.jsonObjectToMap(unit.getJsonObject()));
+                displayUnitList.add(Utils.jsonToMapWithRecursion(unit.getJsonObject()));
             }
         }
         return displayUnitList;

--- a/android/src/main/java/com/clevertap/clevertap_plugin/Utils.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/Utils.java
@@ -9,6 +9,7 @@ import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.events.EventDetail;
 import com.clevertap.android.sdk.inbox.CTInboxMessage;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.json.JSONArray;
@@ -126,6 +127,48 @@ public class Utils {
         }
         return stringObjectMap;
     }
+
+    /**
+     * Converts the entire Json(includes nested objects/array) into a Dart compatible Map type.
+     * @param json - target json
+     * @return - the converted Dart compatible Map type
+     */
+    public static Map<String, Object> jsonToMapWithRecursion(JSONObject json) {
+        Map<String, Object> map = new HashMap<>();
+        Iterator<String> keys = json.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value;
+            try {
+                value = json.get(key);
+                if (value instanceof JSONArray) {
+                    value = jsonArrayToList((JSONArray) value);
+                } else if (value instanceof JSONObject) {
+                    value = jsonToMapWithRecursion((JSONObject) value);
+                }
+                map.put(key, value);
+            } catch (JSONException | NullPointerException e) {
+                Log.e("CleverTapError", "Map to JSON error", e);
+                return map;
+            }
+        }
+        return map;
+    }
+
+    private static List<Object> jsonArrayToList(JSONArray array) throws JSONException {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if (value instanceof JSONArray) {
+                value = jsonArrayToList((JSONArray) value);
+            } else if (value instanceof JSONObject) {
+                value = jsonToMapWithRecursion((JSONObject) value);
+            }
+            list.add(value);
+        }
+        return list;
+    }
+
 
     @SuppressWarnings("rawtypes")
     static Bundle jsonToBundle(JSONObject jsonObject) throws JSONException {

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -181,6 +181,36 @@ var styleConfig = {
 CleverTapPlugin.showInbox(styleConfig);
 ```
 
+#### App Inbox Item Click Callback
+
+```Dart
+_clevertapPlugin.setCleverTapInboxNotificationMessageClickedHandler(inboxNotificationMessageClicked);
+
+void inboxNotificationMessageClicked(Map<String, dynamic>? data, int contentPageIndex, int buttonIndex) {
+    this.setState(() {
+      print("App Inbox item: ${data.toString()}");
+      print("Content Page index: $contentPageIndex");
+      print("Button index: $buttonIndex");
+    });
+}
+```
+
+#### App Inbox Button Click Callback
+```Dart
+_clevertapPlugin.setCleverTapInboxNotificationButtonClickedHandler(inboxNotificationButtonClicked);
+
+void inboxNotificationButtonClicked(Map<String, dynamic>? map) {
+  this.setState(() {
+    print("inboxNotificationButtonClicked called = ${map.toString()}");
+  });
+}
+```
+
+#### Dismiss the App Inbox
+```Dart
+CleverTapPlugin.dismissInbox();
+```
+
 #### Get Total Inbox Message Count
 
 ```Dart

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - CleverTap-iOS-SDK (4.1.4):
-    - SDWebImage (~> 5.1)
-  - clevertap_plugin (1.5.4):
-    - CleverTap-iOS-SDK (= 4.1.4)
+  - CleverTap-iOS-SDK (4.2.1):
+    - SDWebImage (~> 5.11)
+  - clevertap_plugin (1.5.5):
+    - CleverTap-iOS-SDK (= 4.2.1)
     - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.13.4):
-    - SDWebImage/Core (= 5.13.4)
-  - SDWebImage/Core (5.13.4)
+  - SDWebImage (5.15.5):
+    - SDWebImage/Core (= 5.15.5)
+  - SDWebImage/Core (5.15.5)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: ec4a641fcec7255759252eb91ff3ee603bd5e5e3
-  clevertap_plugin: 929e3b76940daf4a2dbacfd5130708bd249da857
+  CleverTap-iOS-SDK: fa1dc112e97829410b15ea456564cb9d552ce23e
+  clevertap_plugin: 4a176ca6b813993b4afbadea51cf39c0de1a5ab7
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
+  SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - CleverTap-iOS-SDK (4.2.1):
+  - CleverTap-iOS-SDK (4.2.2):
     - SDWebImage (~> 5.11)
-  - clevertap_plugin (1.5.5):
-    - CleverTap-iOS-SDK (= 4.2.1)
+  - clevertap_plugin (1.5.6):
+    - CleverTap-iOS-SDK (= 4.2.2)
     - Flutter
   - Flutter (1.0.0)
   - SDWebImage (5.15.5):
@@ -25,8 +25,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: fa1dc112e97829410b15ea456564cb9d552ce23e
-  clevertap_plugin: 4a176ca6b813993b4afbadea51cf39c0de1a5ab7
+  CleverTap-iOS-SDK: 36c21b8a671d87a0f9c7b389b339d02528bbe4d7
+  clevertap_plugin: 5a95d1d56cf219a71089892ac7a02355e6b42eab
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,10 +87,55 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  void inboxNotificationMessageClicked(Map<String, dynamic>? map) {
+  void inboxNotificationMessageClicked(
+      Map<String, dynamic>? data, int itemIndex, int buttonIndex) {
     this.setState(() {
-      print("inboxNotificationMessageClicked called = ${map.toString()}");
+      print(
+          "inboxNotificationMessageClicked called = InboxItemClicked at $itemIndex position with button-index: $buttonIndex");
+
+      //The buttonIndex corresponds to the CTA button clicked (0, 1, or 2). A value of -1 indicates the app inbox body/message clicked.
+      if (buttonIndex != -1) {
+        //button is clicked
+        var message = json.decode(data?["msg"]);
+        if (message != null) {
+          List? messageContentList = message["content"];
+          if (messageContentList != null && messageContentList.length > 0) {
+            var content = messageContentList[0];
+            var buttonObject = content["action"]["links"][buttonIndex];
+            var buttonType = buttonObject["type"];
+            switch (buttonType) {
+              case "copy":
+                //this type copies the associated text to the clipboard
+                var copiedText = buttonObject["copyText"]?["text"];
+                print("copied text to Clipboard: $copiedText");
+                //dismissAppInbox();
+                break;
+              case "url":
+                //this type fires the deeplink
+                var firedDeepLinkUrl = buttonObject["url"]?["android"]?["text"];
+                print("fired deeplink url: $firedDeepLinkUrl");
+                //dismissAppInbox();
+                break;
+              case "kv":
+                {
+                  //this type contains the custom key-value pairs
+                  var kvPair = buttonObject["kv"];
+                  print("custom key-value pair: $kvPair");
+                  //dismissAppInbox();
+                }
+            }
+          }
+        }
+      } else {
+        //Item's body is clicked
+        print("type/template of App Inbox item: ${data.toString()}");
+        //dismissAppInbox();
+      }
     });
+  }
+
+  void dismissAppInbox() {
+    CleverTapPlugin.dismissInbox();
   }
 
   void profileDidInitialize() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -168,8 +168,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void onDisplayUnitsLoaded(List<dynamic>? displayUnits) {
-    this.setState(() async {
-      List? displayUnits = await CleverTapPlugin.getAllDisplayUnits();
+    this.setState(() {
       print("Display Units = " + displayUnits.toString());
     });
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -170,7 +170,20 @@ class _MyAppState extends State<MyApp> {
 
   void onDisplayUnitsLoaded(List<dynamic>? displayUnits) {
     this.setState(() {
-      print("Display Units = " + displayUnits.toString());
+      print("onDisplayUnitsLoaded called");
+      processDisplayUnits(displayUnits);
+    });
+  }
+
+  void processDisplayUnits(List<dynamic>? displayUnits) {
+    showToast("check console for logs");
+    print("Display Units Payload = " + displayUnits.toString());
+
+    displayUnits?.forEach((element) {
+      var customExtras = element["custom_kv"];
+      if (customExtras != null) {
+        print("Display Units CustomExtras: " +  customExtras.toString());
+      }
     });
   }
 
@@ -1840,8 +1853,7 @@ class _MyAppState extends State<MyApp> {
 
   void getAdUnits() async {
     List? displayUnits = await CleverTapPlugin.getAllDisplayUnits();
-    showToast("check console for logs");
-    print("Display Units = " + displayUnits.toString());
+    processDisplayUnits(displayUnits);
   }
 
   void fetch() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,10 +93,11 @@ class _MyAppState extends State<MyApp> {
       print(
           "inboxNotificationMessageClicked called = InboxItemClicked at $itemIndex position with button-index: $buttonIndex");
 
+      var message = data?["msg"];
+
       //The buttonIndex corresponds to the CTA button clicked (0, 1, or 2). A value of -1 indicates the app inbox body/message clicked.
       if (buttonIndex != -1) {
         //button is clicked
-        var message = data?["msg"];
         if (message != null) {
           List? messageContentList = message["content"];
           if (messageContentList != null && messageContentList.length > 0) {
@@ -128,7 +129,7 @@ class _MyAppState extends State<MyApp> {
         }
       } else {
         //Item's body is clicked
-        print("type/template of App Inbox item: ${data.toString()}");
+        print("type/template of App Inbox item: ${message["type"]}");
         //dismissAppInbox();
       }
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,48 +88,49 @@ class _MyAppState extends State<MyApp> {
   }
 
   void inboxNotificationMessageClicked(
-      Map<String, dynamic>? data, int itemIndex, int buttonIndex) {
+      Map<String, dynamic>? data, int contentPageIndex, int buttonIndex) {
     this.setState(() {
       print(
-          "inboxNotificationMessageClicked called = InboxItemClicked at $itemIndex position with button-index: $buttonIndex");
+          "inboxNotificationMessageClicked called = InboxItemClicked at page-index $contentPageIndex with button-index $buttonIndex");
 
-      var message = data?["msg"];
+      var inboxMessageClicked = data?["msg"];
+      if (inboxMessageClicked == null) {
+        return;
+      }
+
+      //The contentPageIndex corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the value is always 0, as they only have one page of content.
+      var messageContentObject =
+      inboxMessageClicked["content"][contentPageIndex];
 
       //The buttonIndex corresponds to the CTA button clicked (0, 1, or 2). A value of -1 indicates the app inbox body/message clicked.
       if (buttonIndex != -1) {
         //button is clicked
-        if (message != null) {
-          List? messageContentList = message["content"];
-          if (messageContentList != null && messageContentList.length > 0) {
-            var content = messageContentList[0];
-            var buttonObject = content["action"]["links"][buttonIndex];
-            var buttonType = buttonObject["type"];
-            switch (buttonType) {
-              case "copy":
-                //this type copies the associated text to the clipboard
-                var copiedText = buttonObject["copyText"]?["text"];
-                print("copied text to Clipboard: $copiedText");
-                //dismissAppInbox();
-                break;
-              case "url":
-                //this type fires the deeplink
-                var firedDeepLinkUrl = buttonObject["url"]?["android"]?["text"];
-                print("fired deeplink url: $firedDeepLinkUrl");
-                //dismissAppInbox();
-                break;
-              case "kv":
-                {
-                  //this type contains the custom key-value pairs
-                  var kvPair = buttonObject["kv"];
-                  print("custom key-value pair: $kvPair");
-                  //dismissAppInbox();
-                }
-            }
-          }
+        var buttonObject = messageContentObject["action"]["links"][buttonIndex];
+        var buttonType = buttonObject?["type"];
+        switch (buttonType) {
+          case "copy":
+          //this type copies the associated text to the clipboard
+            var copiedText = buttonObject["copyText"]?["text"];
+            print("copied text to Clipboard: $copiedText");
+            //dismissAppInbox();
+            break;
+          case "url":
+          //this type fires the deeplink
+            var firedDeepLinkUrl = buttonObject["url"]?["android"]?["text"];
+            print("fired deeplink url: $firedDeepLinkUrl");
+            //dismissAppInbox();
+            break;
+          case "kv":
+          //this type contains the custom key-value pairs
+            var kvPair = buttonObject["kv"];
+            print("custom key-value pair: $kvPair");
+            //dismissAppInbox();
+            break;
         }
       } else {
         //Item's body is clicked
-        print("type/template of App Inbox item: ${message["type"]}");
+        print(
+            "type/template of App Inbox item: ${inboxMessageClicked["type"]}");
         //dismissAppInbox();
       }
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,7 +96,7 @@ class _MyAppState extends State<MyApp> {
       //The buttonIndex corresponds to the CTA button clicked (0, 1, or 2). A value of -1 indicates the app inbox body/message clicked.
       if (buttonIndex != -1) {
         //button is clicked
-        var message = json.decode(data?["msg"]);
+        var message = data?["msg"];
         if (message != null) {
           List? messageContentList = message["content"];
           if (messageContentList != null && messageContentList.length > 0) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.5.5"
   clock:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.5"
+    version: "1.5.6"
   clock:
     dependency: transitive
     description:

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -237,6 +237,8 @@ static NSDateFormatter *dateFormatter;
         result(nil);
     else if ([@"setHuaweiPushToken" isEqualToString:call.method])
         result(nil);
+    else if ([@"dismissInbox" isEqualToString:call.method])
+        [self dismissInbox];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -1060,47 +1062,17 @@ static NSDateFormatter *dateFormatter;
 }
 
 - (void)messageDidSelect:(CleverTapInboxMessage *_Nonnull)message atIndex:(int)index withButtonIndex:(int)buttonIndex {
-    BOOL dismissInbox = [self shouldDismissInboxController:message.content[index] withButtonIndex:buttonIndex];
-    // Close the inbox controller if deeplink url is present on message or button tap.
-    if (dismissInbox) {
-        [self dismissCleverTapInboxViewController];
-    }
-    
     NSMutableDictionary *body = [NSMutableDictionary new];
     if ([message json] != nil) {
-        body = [NSMutableDictionary dictionaryWithDictionary:[message json]];
+        body[@"data"] = [NSMutableDictionary dictionaryWithDictionary:[message json]];
     }
+    body[@"itemIndex"] = @(index);
+    body[@"buttonIndex"] = @(buttonIndex);
     [self postNotificationWithName:kCleverTapInboxMessageTapped andBody:body];
 }
 
-- (BOOL)shouldDismissInboxController:(CleverTapInboxMessageContent *)content withButtonIndex:(int)buttonIndex {
-    if (buttonIndex < 0 && content.actionHasUrl) {
-        if (content.actionUrl && content.actionUrl.length > 0) {
-            return YES;
-        }
-    }
-    if (buttonIndex > 0 && content.actionHasLinks) {
-        NSDictionary *customExtras = [content customDataForLinkAtIndex:buttonIndex];
-        if (customExtras && customExtras.count > 0) {
-            return NO;
-        }
-        NSString *linkUrl = [content urlForLinkAtIndex:buttonIndex];
-        if (linkUrl && linkUrl.length > 0) {
-            return YES;
-        }
-    }
-    return NO;
-}
-
-- (void)dismissCleverTapInboxViewController {
-    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-    UIViewController *presentedController = [[keyWindow rootViewController] presentedViewController];
-    if ([presentedController isKindOfClass:[UINavigationController class]]) {
-        UINavigationController *navigationController = (UINavigationController *)presentedController;
-        if ([[navigationController topViewController] isKindOfClass:[CleverTapInboxViewController class]]) {
-            [presentedController dismissViewControllerAnimated:YES completion:nil];
-        }
-    }
+- (void)dismissInbox {
+    [[CleverTap sharedInstance] dismissAppInbox];
 }
 
 #pragma mark CleverTapPushNotificationDelegate

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -927,6 +927,11 @@ static NSDateFormatter *dateFormatter;
     [self.channel invokeMethod:notification.name arguments:notification.userInfo];
 }
 
+- (void)emitEventDisplayUnitsLoaded:(NSNotification *)notification {
+    // Passed CleverTapDisplayUnit Array directly.
+    [self.channel invokeMethod:notification.name arguments:notification.userInfo[@"adUnits"]];
+}
+
 - (void)addObservers {
     
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -955,7 +960,7 @@ static NSDateFormatter *dateFormatter;
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(emitEventInternal:)
+                                             selector:@selector(emitEventDisplayUnitsLoaded:)
                                                  name:kCleverTapDisplayUnitsLoaded
                                                object:nil];
     

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '1.5.5'
+  s.version                  = '1.5.6'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '4.2.1'
+  s.dependency               'CleverTap-iOS-SDK', '4.2.2'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '4.1.4'
+  s.dependency               'CleverTap-iOS-SDK', '4.2.1'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -51,7 +51,8 @@ class CleverTapPlugin {
   late CleverTapPushClickedPayloadReceivedHandler
       cleverTapPushClickedPayloadReceivedHandler;
 
-  static const MethodChannel _channel = const MethodChannel('clevertap_plugin');
+  static const MethodChannel _dartToNativeMethodChannel = const MethodChannel('clevertap_plugin/dart_to_native');
+  static const MethodChannel _nativeToDartMethodChannel = const MethodChannel('clevertap_plugin/native_to_dart');
 
   static final CleverTapPlugin _clevertapPlugin =
       new CleverTapPlugin._internal();
@@ -59,7 +60,7 @@ class CleverTapPlugin {
   factory CleverTapPlugin() => _clevertapPlugin;
 
   CleverTapPlugin._internal() {
-    _channel.setMethodCallHandler(_platformCallHandler);
+    _nativeToDartMethodChannel.setMethodCallHandler(_platformCallHandler);
   }
 
   Future _platformCallHandler(MethodCall call) async {
@@ -95,10 +96,10 @@ class CleverTapPlugin {
       case "onInboxMessageClick":
         Map<dynamic, dynamic> args = call.arguments;
         Map<dynamic, dynamic> message = args["data"];
-        int index = args["contentPageIndex"];
+        int contentPageIndex = args["contentPageIndex"];
         int buttonIndex = args["buttonIndex"];
         cleverTapInboxNotificationMessageClickedHandler(
-            message.cast<String, dynamic>(),index,buttonIndex);
+            message.cast<String, dynamic>(), contentPageIndex, buttonIndex);
         break;
       case "onDisplayUnitsLoaded":
         List<dynamic>? args = call.arguments;
@@ -205,33 +206,33 @@ class CleverTapPlugin {
 
   /// Sets debug level to show logs on Android Studio/Xcode console
   static Future<void> setDebugLevel(int value) async {
-    return await _channel.invokeMethod('setDebugLevel', {'debugLevel': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setDebugLevel', {'debugLevel': value});
   }
 
   /// Only for iOS - Registers the application to receive push notifications
   static Future<void> registerForPush() async {
-    return await _channel.invokeMethod('registerForPush', {});
+    return await _dartToNativeMethodChannel.invokeMethod('registerForPush', {});
   }
 
   /// Set the FCM Token for Push Notifications
   static Future<void> setPushToken(String value) async {
-    return await _channel.invokeMethod('setPushToken', {'token': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setPushToken', {'token': value});
   }
 
   /// Set the Xiaomi Token for Push Notifications
   static Future<void> setXiaomiPushToken(String value, String region) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('setXiaomiPushToken', {'token': value, 'region': region});
   }
 
   /// Set the Baidu Token for Push Notifications
   static Future<void> setBaiduPushToken(String value) async {
-    return await _channel.invokeMethod('setBaiduPushToken', {'token': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setBaiduPushToken', {'token': value});
   }
 
   /// Set the Huawei Token for Push Notifications
   static Future<void> setHuaweiPushToken(String value) async {
-    return await _channel.invokeMethod('setHuaweiPushToken', {'token': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setHuaweiPushToken', {'token': value});
   }
 
   /// Method to create Notification Channel
@@ -241,7 +242,7 @@ class CleverTapPlugin {
       String channelDescription,
       int importance,
       bool showBadge) async {
-    return await _channel.invokeMethod('createNotificationChannel', {
+    return await _dartToNativeMethodChannel.invokeMethod('createNotificationChannel', {
       'channelId': channelId,
       'channelName': channelName,
       'channelDescription': channelDescription,
@@ -258,7 +259,7 @@ class CleverTapPlugin {
       int importance,
       bool showBadge,
       String sound) async {
-    return await _channel.invokeMethod('createNotificationChannelWithSound', {
+    return await _dartToNativeMethodChannel.invokeMethod('createNotificationChannelWithSound', {
       'channelId': channelId,
       'channelName': channelName,
       'channelDescription': channelDescription,
@@ -276,7 +277,7 @@ class CleverTapPlugin {
       int importance,
       String groupId,
       bool showBadge) async {
-    return await _channel.invokeMethod('createNotificationChannelWithGroupId', {
+    return await _dartToNativeMethodChannel.invokeMethod('createNotificationChannelWithGroupId', {
       'channelId': channelId,
       'channelName': channelName,
       'channelDescription': channelDescription,
@@ -295,7 +296,7 @@ class CleverTapPlugin {
       String groupId,
       bool showBadge,
       String sound) async {
-    return await _channel.invokeMethod('createNotificationChannelWithGroupId', {
+    return await _dartToNativeMethodChannel.invokeMethod('createNotificationChannelWithGroupId', {
       'channelId': channelId,
       'channelName': channelName,
       'channelDescription': channelDescription,
@@ -309,84 +310,84 @@ class CleverTapPlugin {
   /// Method to create Notification Channel Group
   static Future<void> createNotificationChannelGroup(
       String groupId, String groupName) async {
-    return await _channel.invokeMethod('createNotificationChannelGroup',
+    return await _dartToNativeMethodChannel.invokeMethod('createNotificationChannelGroup',
         {'groupId': groupId, 'groupName': groupName});
   }
 
   /// Method to delete Notification Channel
   static Future<void> deleteNotificationChannel(String channelId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('deleteNotificationChannel', {'channelId': channelId});
   }
 
   /// Method to delete Notification Channel Group
   static Future<void> deleteNotificationChannelGroup(String groupId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('deleteNotificationChannelGroup', {'groupId': groupId});
   }
 
   /// Method to create Notification using CleverTap
   static Future<void> createNotification(dynamic data) async {
     print("inside createNotification Dart");
-    return await _channel.invokeMethod('createNotification', {'extras': data});
+    return await _dartToNativeMethodChannel.invokeMethod('createNotification', {'extras': data});
   }
 
   /// Method to process Notification using CleverTap to avoid duplicates using Push Amplification
   static Future<void> processPushNotification(dynamic data) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('processPushNotification', {'extras': data});
   }
 
   /// Method to allow user to Opt out of sending data to CleverTap as per GDPR rules
   static Future<void> setOptOut(bool value) async {
-    return await _channel.invokeMethod('setOptOut', {'value': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setOptOut', {'value': value});
   }
 
   /// Sets the CleverTap SDK to offline
   static Future<void> setOffline(bool value) async {
-    return await _channel.invokeMethod('setOffline', {'value': value});
+    return await _dartToNativeMethodChannel.invokeMethod('setOffline', {'value': value});
   }
 
   /// Enables Device & Networking Information Reporting to CleverTap
   static Future<void> enableDeviceNetworkInfoReporting(bool value) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('enableDeviceNetworkInfoReporting', {'value': value});
   }
 
   /// Enables the Profile/Events Read and Synchronization API
   static Future<void> enablePersonalization() async {
-    return await _channel.invokeMethod('enablePersonalization', {});
+    return await _dartToNativeMethodChannel.invokeMethod('enablePersonalization', {});
   }
 
   /// Disables the Profile/Events Read and Synchronization API
   static Future<void> disablePersonalization() async {
-    return await _channel.invokeMethod('disablePersonalization', {});
+    return await _dartToNativeMethodChannel.invokeMethod('disablePersonalization', {});
   }
 
   ///Record Notification Clicked event
   static Future<void> pushNotificationClickedEvent(
       Map<String, dynamic> extras) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'pushNotificationClickedEvent', {'notificationData': extras});
   }
 
   ///Record Notification Viewed event
   static Future<void> pushNotificationViewedEvent(
       Map<String, dynamic> extras) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'pushNotificationViewedEvent', {'notificationData': extras});
   }
 
   /// Record a Screen View event
   static Future<void> recordScreenView(String screenName) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('recordScreenView', {'screenName': screenName});
   }
 
   /// Pushes a basic event.
   static Future<void> recordEvent(
       String eventName, Map<String, dynamic> properties) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'recordEvent', {'eventName': eventName, 'eventData': properties});
   }
 
@@ -401,25 +402,25 @@ class CleverTapPlugin {
   ///
   static Future<void> recordChargedEvent(Map<String, dynamic> chargeDetails,
       List<Map<String, dynamic>> items) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'recordChargedEvent', {'chargeDetails': chargeDetails, 'items': items});
   }
 
   /// Returns the timestamp of the first time the given event was raised
   static Future<dynamic> eventGetFirstTime(String eventName) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('eventGetFirstTime', {'eventName': eventName});
   }
 
   /// Returns the timestamp of the last time the given event was raised
   static Future<dynamic> eventGetLastTime(String eventName) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('eventGetLastTime', {'eventName': eventName});
   }
 
   /// Returns the total count of the specified event
   static Future<int?> eventGetOccurrences(String eventName) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('eventGetOccurrences', {'eventName': eventName});
   }
 
@@ -427,20 +428,20 @@ class CleverTapPlugin {
   //  and last time timestamp of the event.
   static Future<Map<String, dynamic>> eventGetDetail(String eventName) async {
     Map<dynamic, dynamic> response =
-        await _channel.invokeMethod('eventGetDetail', {'eventName': eventName});
+        await _dartToNativeMethodChannel.invokeMethod('eventGetDetail', {'eventName': eventName});
     return response.cast<String, dynamic>();
   }
 
   /// Returns a Map of event names and corresponding event details of all the events raised
   static Future<Map<String, dynamic>> getEventHistory(String eventName) async {
-    Map<dynamic, dynamic> response = await _channel
+    Map<dynamic, dynamic> response = await _dartToNativeMethodChannel
         .invokeMethod('getEventHistory', {'eventName': eventName});
     return response.cast<String, dynamic>();
   }
 
   /// Set the user profile location in CleverTap
   static Future<void> setLocation(double latitude, double longitude) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'setLocation', {'latitude': latitude, 'longitude': longitude});
   }
 
@@ -449,7 +450,7 @@ class CleverTapPlugin {
 
   /// Returns a unique CleverTap identifier suitable for use with install attribution providers.
   static Future<String?> profileGetCleverTapAttributionIdentifier() async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileGetCleverTapAttributionIdentifier', {});
   }
 
@@ -458,12 +459,12 @@ class CleverTapPlugin {
 
   /// Returns a unique identifier by which CleverTap identifies this user.
   static Future<String?> profileGetCleverTapID() async {
-    return await _channel.invokeMethod('profileGetCleverTapID', {});
+    return await _dartToNativeMethodChannel.invokeMethod('profileGetCleverTapID', {});
   }
 
   /// Returns a unique identifier through callback by which CleverTap identifies this user
   static Future<String?> getCleverTapID() async {
-    return await _channel.invokeMethod('getCleverTapID', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getCleverTapID', {});
   }
 
   ///  Creates a separate and distinct user profile identified by one or more of Identity,
@@ -495,17 +496,17 @@ class CleverTapPlugin {
   ///  @param profile The map keyed by the type of identity, with the value as the identity
   ///
   static Future<void> onUserLogin(Map<String, dynamic> profile) async {
-    return await _channel.invokeMethod('onUserLogin', {'profile': profile});
+    return await _dartToNativeMethodChannel.invokeMethod('onUserLogin', {'profile': profile});
   }
 
   /// Push a profile update.
   static Future<void> profileSet(Map<String, dynamic> profile) async {
-    return await _channel.invokeMethod('profileSet', {'profile': profile});
+    return await _dartToNativeMethodChannel.invokeMethod('profileSet', {'profile': profile});
   }
 
   ///Remove the user profile property value specified by key from the user profile
   static Future<void> profileRemoveValueForKey(String key) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileRemoveValueForKey', {'key': key});
   }
 
@@ -513,7 +514,7 @@ class CleverTapPlugin {
   /// Max 100 values, on reaching 100 cap, oldest value(s) will be removed.
   /// Values must be Strings and are limited to 512 characters.
   static Future<void> profileSetMultiValues(String key, List values) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileSetMultiValues', {'key': key, 'values': values});
   }
 
@@ -526,19 +527,19 @@ class CleverTapPlugin {
   /// If the key currently contains a scalar value, the key will be promoted to a multi-value property
   /// with the current value cast to a string and the new value(s) added
   static Future<void> profileAddMultiValue(String key, String value) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileAddMultiValue', {'key': key, 'value': value});
   }
 
   ///Increment given num value. The value should be in positive range
   static Future<void> profileIncrementValue(String key, num value) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileIncrementValue', {'key': key, 'value': value});
   }
 
   ///Decrement given num value. The value should be in positive range
   static Future<void> profileDecrementValue(String key, num value) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileDecrementValue', {'key': key, 'value': value});
   }
 
@@ -551,7 +552,7 @@ class CleverTapPlugin {
   /// If the key currently contains a scalar value, the key will be promoted to a multi-value property
   /// with the current value cast to a string and the new value(s) added
   static Future<void> profileAddMultiValues(String key, List values) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileAddMultiValues', {'key': key, 'values': values});
   }
 
@@ -561,7 +562,7 @@ class CleverTapPlugin {
   /// the key will be promoted to a multi-value property with the current value cast to a string.
   /// If the multi-value property is empty after the remove operation, the key will be removed.
   static Future<void> profileRemoveMultiValue(String key, String value) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('profileRemoveMultiValue', {'key': key, 'value': value});
   }
 
@@ -571,41 +572,41 @@ class CleverTapPlugin {
   /// the key will be promoted to a multi-value property with the current value cast to a string.
   /// If the multi-value property is empty after the remove operation, the key will be removed.
   static Future<void> profileRemoveMultiValues(String key, List values) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'profileRemoveMultiValues', {'key': key, 'values': values});
   }
 
   /// This method is used to push install referrer via UTM source, medium & campaign parameters
   static Future<void> pushInstallReferrer(
       String source, String medium, String campaign) async {
-    return await _channel.invokeMethod('pushInstallReferrer',
+    return await _dartToNativeMethodChannel.invokeMethod('pushInstallReferrer',
         {'source': source, 'medium': medium, 'campaign': campaign});
   }
 
   /// Returns the time elapsed by the user on the app
   static Future<dynamic> sessionGetTimeElapsed() async {
-    return await _channel.invokeMethod('sessionGetTimeElapsed', {});
+    return await _dartToNativeMethodChannel.invokeMethod('sessionGetTimeElapsed', {});
   }
 
   /// Returns the total number of times the app has been launched
   static Future<int?> sessionGetTotalVisits() async {
-    return await _channel.invokeMethod('sessionGetTotalVisits', {});
+    return await _dartToNativeMethodChannel.invokeMethod('sessionGetTotalVisits', {});
   }
 
   /// Returns the number of screens which have been displayed by the app
   static Future<int?> sessionGetScreenCount() async {
-    return await _channel.invokeMethod('sessionGetScreenCount', {});
+    return await _dartToNativeMethodChannel.invokeMethod('sessionGetScreenCount', {});
   }
 
   /// Returns the timestamp of the previous visit
   static Future<dynamic> sessionGetPreviousVisitTime() async {
-    return await _channel.invokeMethod('sessionGetPreviousVisitTime', {});
+    return await _dartToNativeMethodChannel.invokeMethod('sessionGetPreviousVisitTime', {});
   }
 
   /// Returns a Map of UTMDetail object which consists of UTM parameters like source, medium & campaign
   static Future<Map<String, dynamic>> sessionGetUTMDetails() async {
     Map<dynamic, dynamic> response =
-        await _channel.invokeMethod('sessionGetUTMDetails', {});
+        await _dartToNativeMethodChannel.invokeMethod('sessionGetUTMDetails', {});
     return response.cast<String, dynamic>();
   }
 
@@ -615,14 +616,14 @@ class CleverTapPlugin {
   /// The InApp Notifications are queued once this method is called
   /// and will be displayed once resumeInAppNotifications() is called.
   static Future<void> suspendInAppNotifications() async {
-    return await _channel.invokeMethod('suspendInAppNotifications', {});
+    return await _dartToNativeMethodChannel.invokeMethod('suspendInAppNotifications', {});
   }
 
   /// Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown
   /// after this method is called.
   /// The InApp Notifications will be displayed only once resumeInAppNotifications() is called.
   static Future<void> discardInAppNotifications() async {
-    return await _channel.invokeMethod('discardInAppNotifications', {});
+    return await _dartToNativeMethodChannel.invokeMethod('discardInAppNotifications', {});
   }
 
   /// Resumes display of InApp Notifications.
@@ -632,179 +633,179 @@ class CleverTapPlugin {
   /// If discardInAppNotifications() was called previously, calling this method will only resume
   /// InApp Notifications on events raised after this method is called.
   static Future<void> resumeInAppNotifications() async {
-    return await _channel.invokeMethod('resumeInAppNotifications', {});
+    return await _dartToNativeMethodChannel.invokeMethod('resumeInAppNotifications', {});
   }
 
   /// Initializes the inbox controller and sends a callback
   static Future<void> initializeInbox() async {
-    return await _channel.invokeMethod('initializeInbox', {});
+    return await _dartToNativeMethodChannel.invokeMethod('initializeInbox', {});
   }
 
   /// Opens CTInboxActivity to display Inbox Messages
   static Future<void> showInbox(Map<String, dynamic> styleConfig) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('showInbox', {'styleConfig': styleConfig});
   }
 
   ///Dismisses the App Inbox screen
   static Future<void> dismissInbox() async {
-    return await _channel.invokeMethod('dismissInbox', {});
+    return await _dartToNativeMethodChannel.invokeMethod('dismissInbox', {});
   }
 
   /// Returns the count of all inbox messages for the user
   static Future<int?> getInboxMessageCount() async {
-    return await _channel.invokeMethod('getInboxMessageCount', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getInboxMessageCount', {});
   }
 
   /// Returns the count of total number of unread inbox messages for the user
   static Future<int?> getInboxMessageUnreadCount() async {
-    return await _channel.invokeMethod('getInboxMessageUnreadCount', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getInboxMessageUnreadCount', {});
   }
 
   /// Returns a list of json string representation of all CTInboxMessage
 
   static Future<List?> getAllInboxMessages() async {
-    return await _channel.invokeMethod('getAllInboxMessages', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getAllInboxMessages', {});
   }
 
   /// Returns a list of json string representation of unread CTInboxMessage
   static Future<List?> getUnreadInboxMessages() async {
-    return await _channel.invokeMethod('getUnreadInboxMessages', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getUnreadInboxMessages', {});
   }
 
   /// Returns a json string representation of CTInboxMessage for given messageId
   static Future<Map<String, dynamic>> getInboxMessageForId(
       String messageId) async {
-    Map<dynamic, dynamic> response = await _channel
+    Map<dynamic, dynamic> response = await _dartToNativeMethodChannel
         .invokeMethod('getInboxMessageForId', {'messageId': messageId});
     return response.cast<String, dynamic>();
   }
 
   /// Deletes the CTInboxMessage object for given messageId
   static Future<void> deleteInboxMessageForId(String messageId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('deleteInboxMessageForId', {'messageId': messageId});
   }
 
   /// Marks the given messageId of CTInboxMessage object as read
   static Future<void> markReadInboxMessageForId(String messageId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('markReadInboxMessageForId', {'messageId': messageId});
   }
 
   /// Pushes the Notification Clicked event for App Inbox to CleverTap.
   static Future<void> pushInboxNotificationClickedEventForId(
       String messageId) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'pushInboxNotificationClickedEventForId', {'messageId': messageId});
   }
 
   /// Pushes the Notification Viewed event for App Inbox to CleverTap.
   static Future<void> pushInboxNotificationViewedEventForId(
       String messageId) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'pushInboxNotificationViewedEventForId', {'messageId': messageId});
   }
 
   /// only iOS - If an application is launched from a push notification click, returns the CleverTap deep link included in the push notification
   static Future<String?> getInitialUrl() async {
-    return await _channel.invokeMethod('getInitialUrl', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getInitialUrl', {});
   }
 
   ///Display units
   ///Returns a List of Display units as a Map
   static Future<List?> getAllDisplayUnits() async {
-    return await _channel.invokeMethod('getAllDisplayUnits', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getAllDisplayUnits', {});
   }
 
   ///Returns Display unit info as a Map
   static Future<Map<String, dynamic>> getDisplayUnitForId(String unitId) async {
     Map<dynamic, dynamic> response =
-        await _channel.invokeMethod('getDisplayUnitForId', {'unitId': unitId});
+        await _dartToNativeMethodChannel.invokeMethod('getDisplayUnitForId', {'unitId': unitId});
     return response.cast<String, dynamic>();
   }
 
   ///Raise Notification Viewed for Display Unit id passed
   static Future<void> pushDisplayUnitViewedEvent(String unitId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('pushDisplayUnitViewedEvent', {'unitId': unitId});
   }
 
   ///Raise Notification Clicked for Display Unit id passed
   static Future<void> pushDisplayUnitClickedEvent(String unitId) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('pushDisplayUnitClickedEvent', {'unitId': unitId});
   }
 
   ///Feature Flags
   ///Returns boolean value of Feature Flag
   static Future<bool?> getFeatureFlag(String key, bool defaultValue) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'getFeatureFlag', {'key': key, 'defaultValue': defaultValue});
   }
 
   ///Product Config
   ///Sets Default Values for Product Config using the passed Map
   static Future<void> setDefaultsMap(Map<String, dynamic> defaults) async {
-    return await _channel
+    return await _dartToNativeMethodChannel
         .invokeMethod('setDefaultsMap', {'defaults': defaults});
   }
 
   ///Fetches the Product Configs from CleverTap
   static Future<void> fetch() async {
-    return await _channel.invokeMethod('fetch', {});
+    return await _dartToNativeMethodChannel.invokeMethod('fetch', {});
   }
 
   ///Fetches Product configs, adhering to the specified minimum fetch interval in seconds.
   static Future<void> fetchWithMinimumIntervalInSeconds(int interval) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'fetchWithMinimumFetchIntervalInSeconds', {'interval': interval});
   }
 
   ///Activates the most recently fetched Product configs
   static Future<void> activate() async {
-    return await _channel.invokeMethod('activate', {});
+    return await _dartToNativeMethodChannel.invokeMethod('activate', {});
   }
 
   ///Fetches and then activates the fetched Product configs.
   static Future<void> fetchAndActivate() async {
-    return await _channel.invokeMethod('fetchAndActivate', {});
+    return await _dartToNativeMethodChannel.invokeMethod('fetchAndActivate', {});
   }
 
   ///Sets the minimum interval between successive fetch calls.
   static Future<void> setMinimumFetchIntervalInSeconds(int interval) async {
-    return await _channel.invokeMethod(
+    return await _dartToNativeMethodChannel.invokeMethod(
         'setMinimumFetchIntervalInSeconds', {'interval': interval});
   }
 
   ///Returns the last fetched timestamp in millis.
   static Future<int?> getLastFetchTimeStampInMillis() async {
-    return await _channel.invokeMethod('getLastFetchTimeStampInMillis', {});
+    return await _dartToNativeMethodChannel.invokeMethod('getLastFetchTimeStampInMillis', {});
   }
 
   ///Returns the parameter value for the given key as a String.
   static Future<String?> getProductConfigString(String key) async {
-    return await _channel.invokeMethod('getString', {'key': key});
+    return await _dartToNativeMethodChannel.invokeMethod('getString', {'key': key});
   }
 
   ///Returns the parameter value for the given key as a boolean.
   static Future<bool?> getProductConfigBoolean(String key) async {
-    return await _channel.invokeMethod('getBoolean', {'key': key});
+    return await _dartToNativeMethodChannel.invokeMethod('getBoolean', {'key': key});
   }
 
   ///Returns the parameter value for the given key as a long (int for Dart).
   static Future<int?> getProductConfigLong(String key) async {
-    return await _channel.invokeMethod('getLong', {'key': key});
+    return await _dartToNativeMethodChannel.invokeMethod('getLong', {'key': key});
   }
 
   ///Returns the parameter value for the given key as a double.
   static Future<double?> getProductConfigDouble(String key) async {
-    return await _channel.invokeMethod('getDouble', {'key': key});
+    return await _dartToNativeMethodChannel.invokeMethod('getDouble', {'key': key});
   }
 
   ///Deletes all activated, fetched and defaults configs as well as all Product Config settings.
   static Future<void> resetProductConfig() async {
-    return await _channel.invokeMethod('reset', {});
+    return await _dartToNativeMethodChannel.invokeMethod('reset', {});
   }
 
   static String getCleverTapDate(DateTime dateTime) {

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -95,7 +95,7 @@ class CleverTapPlugin {
       case "onInboxMessageClick":
         Map<dynamic, dynamic> args = call.arguments;
         Map<dynamic, dynamic> message = args["data"];
-        int index = args["itemIndex"];
+        int index = args["contentPageIndex"];
         int buttonIndex = args["buttonIndex"];
         cleverTapInboxNotificationMessageClickedHandler(
             message.cast<String, dynamic>(),index,buttonIndex);

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -13,7 +13,7 @@ typedef void CleverTapInboxMessagesDidUpdateHandler();
 typedef void CleverTapInboxNotificationButtonClickedHandler(
     Map<String, dynamic>? mapList);
 typedef void CleverTapInboxNotificationMessageClickedHandler(
-    Map<String, dynamic>? map);
+    Map<String, dynamic>? message, int index, int buttonIndex);
 typedef void CleverTapDisplayUnitsLoadedHandler(List<dynamic>? displayUnitList);
 typedef void CleverTapFeatureFlagUpdatedHandler();
 typedef void CleverTapProductConfigInitializedHandler();
@@ -94,8 +94,11 @@ class CleverTapPlugin {
         break;
       case "onInboxMessageClick":
         Map<dynamic, dynamic> args = call.arguments;
+        Map<dynamic, dynamic> message = args["data"];
+        int index = args["itemIndex"];
+        int buttonIndex = args["buttonIndex"];
         cleverTapInboxNotificationMessageClickedHandler(
-            args.cast<String, dynamic>());
+            message.cast<String, dynamic>(),index,buttonIndex);
         break;
       case "onDisplayUnitsLoaded":
         List<dynamic>? args = call.arguments;
@@ -641,6 +644,11 @@ class CleverTapPlugin {
   static Future<void> showInbox(Map<String, dynamic> styleConfig) async {
     return await _channel
         .invokeMethod('showInbox', {'styleConfig': styleConfig});
+  }
+
+  ///Dismisses the App Inbox screen
+  static Future<void> dismissInbox() async {
+    return await _channel.invokeMethod('dismissInbox', {});
   }
 
   /// Returns the count of all inbox messages for the user

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 1.5.5
+version: 1.5.6
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
#### Added
* Supports [CleverTap Android SDK v4.6.9](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-469-march-31-2023)
* Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-422-april-03-2023)
* Adds the new public API `dismissInbox()` to dismiss the App Inbox.

#### Changed
* **[Breaking change to the signature of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
  It is changed from `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data)` to `CleverTapInboxNotificationMessageClickedHandler(Map<String, dynamic>? data, int contentPageIndex, int buttonIndex)`. The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the `contentPageIndex` value is always 0, as they only have one page of content. The `buttonIndex` corresponds to the the App Inbox button clicked (0, 1, or 2). A value of -1 in `buttonIndex` field indicates the entire App Inbox Item is clicked.
* **[Behavioral change of the `CleverTapInboxNotificationMessageClickedHandler` callback]**:
  Previously, the callback was raised when the App Inbox Item is clicked. Now, it is also raised when the App Inbox button is clicked besides the item click.
* **[Native Display parity changes]**:
  - Streamlines the format of native display payload across Android and iOS.
  - Streamlines the argument of `onDisplayUnitsLoaded` callback method in iOS to pass the list of displayUnits.

#### Fixed
* Fixes the FCM Plugin's [onBackgroundMessage handler bug](https://github.com/CleverTap/clevertap-flutter/commit/8db6f34eec83e7f14990359f88c65a50e966acb3) which was breaking the CleverTap Plugin's platform channel for sending method calls from Android to Dart platform.
* Fixes the Xcode 14.3+ compilation errors in iOS.