### PR TITLE
[SDK 2848] Pass Flutter SDK version to Core SDK

### DIFF
--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -1572,7 +1572,6 @@ public class CleverTapPlugin implements ActivityAware,
             this.cleverTapAPI.setCTFeatureFlagsListener(this);
             this.cleverTapAPI.setCTProductConfigListener(this);
             this.cleverTapAPI.setCTPushAmpListener(this);
-            this.cleverTapAPI.setLibrary("Flutter");
             this.cleverTapAPI.registerPushPermissionNotificationResponseListener(this);
         }
     }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -200,6 +200,9 @@ public class CleverTapPlugin implements ActivityAware,
     @Override
     public void onMethodCall(MethodCall call, @NonNull Result result) {
         switch (call.method) {
+            case "setLibrary": {
+                setLibrary(call, result);
+            }
             case "setDebugLevel": {
                 int debugLevelValue = call.argument("debugLevel");
                 CleverTapAPI.setDebugLevel(debugLevelValue);
@@ -609,6 +612,18 @@ public class CleverTapPlugin implements ActivityAware,
             }
         }
 
+    }
+
+    @SuppressLint("RestrictedApi")
+    private void setLibrary(MethodCall call, Result result) {
+        String libName = call.argument("libName");
+        int libVersion = call.argument("libVersion");
+        if (isCleverTapNotNull(cleverTapAPI)) {
+            cleverTapAPI.setCustomSdkVersion(libName, libVersion);
+            result.success(null);
+        } else {
+            result.error(TAG, ERROR_MSG, null);
+        }
     }
 
     @Override

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -59,7 +59,6 @@ static NSDateFormatter *dateFormatter;
         [[clevertap productConfig] setDelegate:self];
         [[clevertap featureFlags] setDelegate:self];
         [clevertap setPushNotificationDelegate:self];
-        [clevertap setLibrary:@"Flutter"];
         [clevertap setPushPermissionDelegate:self];
         [self addObservers];
     }
@@ -241,6 +240,8 @@ static NSDateFormatter *dateFormatter;
         result(nil);
     else if ([@"setHuaweiPushToken" isEqualToString:call.method])
         result(nil);
+    else if ([@"setLibrary" isEqualToString:call.method])
+        [self setLibrary:call withResult:result];
     else if ([@"promptPushPrimer" isEqualToString:call.method])
         [self promptPushPrimer:call withResult:result];
     else if ([@"promptForPushNotification" isEqualToString:call.method])
@@ -301,6 +302,11 @@ static NSDateFormatter *dateFormatter;
         [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
     }
     result(nil);
+}
+
+- (void)setLibrary:(FlutterMethodCall*)call withResult:(FlutterResult)result {
+    [[CleverTap sharedInstance] setLibrary:call.arguments[@"libName"]];
+    [[CleverTap sharedInstance] setCustomSdkVersion:call.arguments[@"libName"] version:[call.arguments[@"libVersion"]intValue]];
 }
 
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -65,7 +65,12 @@ class CleverTapPlugin {
 
   factory CleverTapPlugin() => _clevertapPlugin;
 
+  static const libName = 'Flutter';
+  static const libVersion = 10602; // If the current version is X.X.X then pass as X0X0X
+
   CleverTapPlugin._internal() {
+    /// Set the CleverTap Flutter library name and the current version for version tracking
+    _dartToNativeMethodChannel.invokeMethod('setLibrary', {'libName': libName, 'libVersion': libVersion});
     _nativeToDartMethodChannel.setMethodCallHandler(_platformCallHandler);
   }
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -66,7 +66,7 @@ class CleverTapPlugin {
   factory CleverTapPlugin() => _clevertapPlugin;
 
   static const libName = 'Flutter';
-  static const libVersion = 10602; // If the current version is X.X.X then pass as X0X0X
+  static const libVersion = 10700; // If the current version is X.X.X then pass as X0X0X
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking


### PR DESCRIPTION
Modified the `clevertap_plugin.dart` to send the version and type of the current CleverTap Flutter SDK to the Core SDKs, allowing for version tracking. This involves sending information about the library type (Flutter) and its version.