### PR TITLE
[SDK 3039] Fix datatype handling for processPushNotification method

### DIFF
--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -1107,10 +1107,10 @@ public class CleverTapPlugin implements ActivityAware,
     }
 
     private void processPushNotification(MethodCall call, Result result) {
-        JSONObject extras = call.argument("extras");
+        Map<String, Object> extras = call.argument("extras");
         if (isCleverTapNotNull(cleverTapAPI)) {
             try {
-                CleverTapAPI.processPushNotification(context, Utils.jsonToBundle(extras));
+                CleverTapAPI.processPushNotification(context, Utils.jsonToBundle(new JSONObject(extras)));
             } catch (JSONException e) {
                 result.error(TAG, "Unable to render notification due to JSONException - " + e.getLocalizedMessage(),
                         null);


### PR DESCRIPTION
Fixed the data handling for `Map` type to convert into a Bundle format to process the notification.
    
-  Earlier, android module is getting the map type from dart into a JsonObject type which was raising the type handling exception.
-  Issue has been fixed by handling the map type in a map variable.
