### PR TITLE
SDK 3319: Supports iOS SDK v5.2.1 with NSLocale and Carrier changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## CHANGE LOG
 
+### Version 1.9.1 *(20th October 2023)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v5.2.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-521-october-12-2023).
+  * Adds Custom Proxy Domain functionality for Push Impressions and Events raised from CleverTap Android SDK. Please refer to [Usage.md](doc/Usage.md#integrate-custom-proxy-domain) file to read more on how to configure custom proxy domains in Android.
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v5.2.1](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/5.2.1).
+  * Adds support to enable `NSFileProtectionComplete` to secure App’s document directory.
+  
+* **[Android and iOS Platform]**
+  * Adds in-built support to send the default locale(i.e.language and country) data to the dashboard and exposed public API `CleverTapPlugin.setLocale(Locale locale)` to set the custom locale, for LP Parity.
+  * Adds support for Integration Debugger to view errors and events on the dashboard when the debugLevel is set to 3 using `CleverTapPlugin.setDebugLevel(3)`.
+
+**Changes**
+* **[iOS Platform]**
+  * Updated logic to retrieve country code using NSLocale above iOS 16 as `CTCarrier` is deprecated above iOS 16 with no replacements, see [Apple Doc](https://developer.apple.com/documentation/coretelephony/ctcarrier).
+  * Updated logic to not send carrier name above iOS 16 in CTCarrier field.
+
+**Bug Fixes**
+* **[iOS Platform]**
+  * Fixes a crash in iOS 17/Xcode 15 related to alert inapps.
+  * Fixes a failing `test_clevertap_instance_nscoding` test case.
+
+
 ### Version 1.9.0 *(29th August 2023)*
 -------------------------------------------
 **What's new**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 **Bug Fixes**
 * **[iOS Platform]**
   * Fixes a crash in iOS 17/Xcode 15 related to alert inapps.
-  * Fixes a failing `test_clevertap_instance_nscoding` test case.
 
 
 ### Version 1.9.0 *(29th August 2023)*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 1.9.0
+clevertap_plugin: 1.9.1
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.clevertap.clevertap_plugin'
-version '1.9.0'
+version '1.9.1'
 
 buildscript {
     repositories {
@@ -42,7 +42,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    api 'com.clevertap.android:clevertap-android-sdk:5.2.0'
+    api 'com.clevertap.android:clevertap-android-sdk:5.2.1'
     compileOnly 'androidx.fragment:fragment:1.3.6'
     compileOnly 'androidx.core:core:1.9.0'
 }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -240,6 +240,10 @@ public class CleverTapPlugin implements ActivityAware,
                 }
                 break;
             }
+            case "setLocale": {
+                setLocale(call, result);
+                break;
+            }
             // Push Methods
             case "setPushToken": {
                 setPushToken(call, result, PushType.FCM);
@@ -698,6 +702,16 @@ public class CleverTapPlugin implements ActivityAware,
             }
         }
 
+    }
+
+    private void setLocale(MethodCall call, Result result) {
+        String locale = call.arguments();
+        if (isCleverTapNotNull(cleverTapAPI)) {
+            cleverTapAPI.setLocale(locale);
+            result.success(null);
+        } else {
+            result.error(TAG, ERROR_MSG, null);
+        }
     }
 
     /**************************************************

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -79,6 +79,13 @@ var lat = 19.07;
 var long = 72.87;
 CleverTapPlugin.setLocation(lat, long);
 ```
+
+#### Set Locale of the user
+
+```Dart
+Locale locale = Locale('en', 'IN');
+CleverTapPlugin.setLocale(locale);
+```
 ----
 
 ## User Events

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -88,6 +88,39 @@ CleverTapPlugin.setLocale(locale);
 ```
 ----
 
+## Integrate Custom Proxy Domain
+The custom proxy domain feature allows to proxy all events raised from the CleverTap SDK through your required domain,
+ideal for handling or relaying CleverTap events and Push Impression events with your application server.
+Refer following steps to configure the custom proxy domain(s) in the manifest file:
+
+#### [Android Platform] Configure Custom Proxy Domain(s) using Manifest file
+1. Add your CleverTap Account credentials in the Manifest file against the `CLEVERTAP_ACCOUNT_ID` and `CLEVERTAP_TOKEN` keys.
+2. Add the **CLEVERTAP_PROXY_DOMAIN** key with the proxy domain value for handling events through the custom proxy domain.
+3. Add the **CLEVERTAP_SPIKY_PROXY_DOMAIN** key with proxy domain value for handling push impression events.
+
+```xml
+        <meta-data
+            android:name="CLEVERTAP_ACCOUNT_ID"
+            android:value="YOUR ACCOUNT ID" />
+        <meta-data
+            android:name="CLEVERTAP_TOKEN"
+            android:value="YOUR ACCOUNT TOKEN" />
+        <meta-data
+            android:name="CLEVERTAP_PROXY_DOMAIN"
+            android:value="YOUR PROXY DOMAIN"/>  <!-- e.g., analytics.sdktesting.xyz -->
+        <meta-data
+            android:name="CLEVERTAP_SPIKY_PROXY_DOMAIN"
+            android:value="YOUR SPIKY PROXY DOMAIN"/>  <!-- e.g., spiky-analytics.sdktesting.xyz -->
+```
+#### [iOS Platform] Configure Custom Proxy Domain(s) using `CleverTap.autoIntegrate()` API
+1. Add your CleverTap Account credentials in the *Info.plist* file against the `CleverTapAccountID` and `CleverTapToken` keys.
+2. Add the `CleverTapProxyDomain` key with the proxy domain value for handling events through the custom proxy domain e.g., *analytics.sdktesting.xyz*.
+3. Add the `CleverTapSpikyProxyDomain` key with proxy domain value for handling push impression events e.g., *spiky-analytics.sdktesting.xyz*.
+4. Import the CleverTap SDK in your *AppDelegate* file and call the following method in the `didFinishLaunchingWithOptions:` method.
+    ``` swift
+      CleverTap.autoIntegrate()
+    ```
+
 ## User Events
 
 #### Record an event 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - CleverTap-iOS-SDK (5.2.0):
+  - CleverTap-iOS-SDK (5.2.1):
     - SDWebImage (~> 5.11)
   - clevertap_plugin (1.7.0):
-    - CleverTap-iOS-SDK (= 5.2.0)
+    - CleverTap-iOS-SDK (= 5.2.1)
     - Flutter
   - Flutter (1.0.0)
-  - SDWebImage (5.17.0):
-    - SDWebImage/Core (= 5.17.0)
-  - SDWebImage/Core (5.17.0)
+  - SDWebImage (5.18.3):
+    - SDWebImage/Core (= 5.18.3)
+  - SDWebImage/Core (5.18.3)
 
 DEPENDENCIES:
   - clevertap_plugin (from `.symlinks/plugins/clevertap_plugin/ios`)
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverTap-iOS-SDK: 6a38eea6d2f0c336fb142baadcca2cd8aafd2290
-  clevertap_plugin: 3bdba39d5b71cf5d9c40eb8a077efd5e2423eb43
+  CleverTap-iOS-SDK: 183b2f5c52ecfcb0d4cc97e0cdfcf080562026f3
+  clevertap_plugin: 85d568eb8f142e6344445bac7eadab4766e1879b
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImage: 96e0c18ef14010b7485210e92fac888587ebb958
 
 PODFILE CHECKSUM: cf0c950f7e9a456b4e325f5b8fc0f98906a3705a
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1365,6 +1365,17 @@ class _MyAppState extends State<MyApp> {
                     ),
                   ),
                 ),
+                Card(
+                  color: Colors.grey.shade300,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: ListTile(
+                      title: Text("Set Locale"),
+                      subtitle: Text("Use to set Locale of a user"),
+                      onTap: setLocale,
+                    ),
+                  ),
+                ),
               ],
             )),
       ),
@@ -1981,6 +1992,12 @@ class _MyAppState extends State<MyApp> {
     var long = 72.87;
     CleverTapPlugin.setLocation(lat, long);
     showToast("Location is set");
+  }
+
+  void setLocale() {
+    Locale locale = Locale('en', 'IN');
+    CleverTapPlugin.setLocale(locale);
+    showToast("Locale is set");
   }
 
   void getCTAttributionId() {

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -274,6 +274,8 @@ static NSDateFormatter *dateFormatter;
         [self onVariablesChanged:call withResult:result];
     else if ([@"onValueChanged" isEqualToString:call.method])
         [self onValueChanged:call withResult:result];
+    else if ([@"setLocale" isEqualToString:call.method])
+        [self setLocale:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -1363,6 +1365,12 @@ static NSDateFormatter *dateFormatter;
             [self postNotificationWithName:kCleverTapOnValueChanged andBody:varResult];
         }];
     }
+}
+
+- (void)setLocale:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:call.arguments];
+    [[CleverTap sharedInstance] setLocale:locale];
+    result(nil);
 }
 
 @end

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '1.7.0'
+  s.version                  = '1.9.1'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '5.2.0'
+  s.dependency               'CleverTap-iOS-SDK', '5.2.1'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -54,7 +54,7 @@ class CleverTapPlugin {
   factory CleverTapPlugin() => _clevertapPlugin;
 
   static const libName = 'Flutter';
-  static const libVersion = 10900; // If the current version is X.X.X then pass as X0X0X
+  static const libVersion = 10901; // If the current version is X.X.X then pass as X0X0X
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -994,4 +994,11 @@ class CleverTapPlugin {
       cleverTapOnValueChangedHandlers.add(handler);
       _dartToNativeMethodChannel.invokeMethod('onValueChanged', {'name': name});
   }
+
+  ///Sets the user locale.
+  static Future<void> setLocale(Locale locale) async {
+    String localeString = locale.toString();
+    return await _dartToNativeMethodChannel.invokeMethod(
+        'setLocale', localeString);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 1.9.0
+version: 1.9.1
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
- Supports CleverTap iOS SDK v5.2.1
- Adds new public API `setLocale(Locale locale)` to set user locale
- Fixes a crash in iOS 17/Xcode 15 related to alert in-apps.