### PR TITLE
Updated package to 2.2.0 and bumped iOS dependency to 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## CHANGE LOG
 
+### Version 2.2.0 *(xx March 2024)*
+-------------------------------------------
+**What's new**
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v6.1.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/6.1.0).
+  
+* **[iOS Platform]**
+  * Adds privacy manifests.
+
+**Bug Fixes**
+* **[iOS Platform]**
+  * Fixes crash due to out of bounds in NSLocale implementation.
+
 ### Version 2.1.0 *(26 February 2024)*
 -------------------------------------------
 **What's new**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 2.1.0
+clevertap_plugin: 2.2.0
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '2.1.0'
+  s.version                  = '2.2.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '6.0.0'
+  s.dependency               'CleverTap-iOS-SDK', '6.1.0'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
  * Supports [CleverTap iOS SDK v6.1.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/6.1.0).
  * Adds privacy manifests.
  * Fixes crash due to out of bounds in NSLocale implementation.