### PR TITLE
feat(SDK-4217): Flushing logic changed for buffers

### DIFF
--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapEvent.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapEvent.kt
@@ -22,7 +22,7 @@ enum class CleverTapEvent(
     CLEVERTAP_PRODUCT_CONFIG_DID_ACTIVATE("CleverTapProductConfigDidActivate"),
     CLEVERTAP_PUSH_NOTIFICATION_CLICKED("CleverTapPushNotificationClicked", bufferable = true),
     CLEVERTAP_ON_PUSH_PERMISSION_RESPONSE("CleverTapPushPermissionResponseReceived"),
-    CLEVERTAP_ON_PUSH_AMP_PAYLOAD_RECEIVED("CleverTapPushPermissionResponseReceived"),
+    CLEVERTAP_ON_PUSH_AMP_PAYLOAD_RECEIVED("CleverTapPushAmpPayloadReceived"), // todo make bufferable?
     CLEVERTAP_ON_VARIABLES_CHANGED("CleverTapOnVariablesChanged"),
     CLEVERTAP_ON_ONE_TIME_VARIABLES_CHANGED("CleverTapOnOneTimeVariablesChanged"),
     CLEVERTAP_ON_VALUE_CHANGED("CleverTapOnValueChanged"),
@@ -31,7 +31,8 @@ enum class CleverTapEvent(
     CLEVERTAP_CUSTOM_TEMPLATE_CLOSE("CleverTapCustomTemplateClose"),
     CLEVERTAP_ON_FILE_VALUE_CHANGED("CleverTapOnFileValueChanged"),
     CLEVERTAP_ON_VARIABLES_CHANGED_AND_NO_DOWNLOADS_PENDING("CleverTapOnVariablesChangedAndNoDownloadsPending"),
-    CLEVERTAP_ONCE_VARIABLES_CHANGED_AND_NO_DOWNLOADS_PENDING("CleverTapOnceVariablesChangedAndNoDownloadsPending");
+    CLEVERTAP_ONCE_VARIABLES_CHANGED_AND_NO_DOWNLOADS_PENDING("CleverTapOnceVariablesChangedAndNoDownloadsPending"),
+    CLEVERTAP_UNKNOWN("CleverTapUnknown");
 
     override fun toString(): String {
         return eventName
@@ -40,8 +41,8 @@ enum class CleverTapEvent(
     companion object {
 
         @JvmStatic
-        fun fromName(eventName: String): CleverTapEvent? {
-            return values().find { it.eventName == eventName }
+        fun fromName(eventName: String): CleverTapEvent {
+            return values().find { it.eventName == eventName } ?: CLEVERTAP_UNKNOWN
         }
     }
 }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapEventEmitter.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapEventEmitter.kt
@@ -116,6 +116,10 @@ object CleverTapEventEmitter {
         params: Any?
     ) {
         try {
+            if (event == CleverTapEvent.CLEVERTAP_UNKNOWN) {
+                Log.i(LOG_TAG, "Not Sending event since its unknown")
+                return
+            }
             invokeMethodOnUiThread(
                 EventNameMapper.fromCleverTapEvent(event),
                 params

--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -56,27 +56,27 @@ public class CleverTapPlugin implements ActivityAware, FlutterPlugin {
 
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+        Log.d(TAG, "onAttachedToActivity: " + binding + " activity " + binding.getActivity());
         activity = new WeakReference<>(binding.getActivity());
-        CleverTapEventEmitter.disableAllAndFlush();
     }
 
     @Override
     public void onDetachedFromActivity() {
+        Log.d(TAG, "onDetachedFromActivity");
         activity.clear();
         activity = null;
-        CleverTapEventEmitter.enableAll();
     }
 
     @SuppressWarnings("ConstantConditions")
     @Override
     public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+        Log.d(TAG, "onReattachedToActivityForConfigChanges: " + binding);
         activity = new WeakReference<>(binding.getActivity());
-        CleverTapEventEmitter.disableAllAndFlush();
     }
 
     @Override
     public void onDetachedFromActivityForConfigChanges() {
-        CleverTapEventEmitter.enableAll();
+        Log.d(TAG, "onDetachedFromActivityForConfigChanges");
         activity.clear();
         activity = null;
     }
@@ -134,7 +134,7 @@ public class CleverTapPlugin implements ActivityAware, FlutterPlugin {
     }
 
     public static void invokeMethodOnUiThread(final String methodName, final String cleverTapID) {
-        Log.d(TAG, "methodChannelSet in invokeMethodOnUiThread(String) is of size " + nativeToDartMethodChannelSet.size());
+        //Log.d(TAG, "methodChannelSet in invokeMethodOnUiThread(String) is of size " + nativeToDartMethodChannelSet.size());
 
         for (MethodChannel channel : nativeToDartMethodChannelSet) {
             if (channel != null) {
@@ -151,7 +151,7 @@ public class CleverTapPlugin implements ActivityAware, FlutterPlugin {
     }
 
     public static void invokeMethodOnUiThread(final String methodName, final Object obj) {
-        Log.d(TAG, "methodChannelSet in invokeMethodOnUiThread(Map) is of size " + nativeToDartMethodChannelSet.size());
+        //Log.d(TAG, "methodChannelSet in invokeMethodOnUiThread(Map) is of size " + nativeToDartMethodChannelSet.size());
 
         for (MethodChannel channel : nativeToDartMethodChannelSet) {
             if (channel != null) {

--- a/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
@@ -52,8 +52,13 @@ class DartToNativePlatformCommunicator(
         private const val ERROR_IOS: String = " method is only applicable for iOS"
 
 
-        private const val ERROR_TEMPLATE_NAME: String =
-            "Custom template: " + " is not currently being presented"
+        private val ERROR_TEMPLATE_NAME: (templateName: String) -> String = { templateName ->
+            "Custom template: $templateName not currently being presented"
+        }
+
+        private val ERROR_EMIT_EVENT_PROBLEM: (name: String?) -> String = { methodName ->
+            "Incorrect Clevertap event disabled, no such event - $methodName"
+        }
 
         private const val KEY_TEMPLATE_NAME_CC: String = "templateName"
 
@@ -67,6 +72,9 @@ class DartToNativePlatformCommunicator(
         result: MethodChannel.Result
     ) {
         when (call.method) {
+            "startEmission" -> {
+                startEmission(call = call, result = result)
+            }
             "getAppLaunchNotification" -> {
                 getAppLaunchNotification(result)
             }
@@ -612,6 +620,28 @@ class DartToNativePlatformCommunicator(
                 result.notImplemented()
             }
         }
+    }
+
+    private fun startEmission(
+        call: MethodCall,
+        result: MethodChannel.Result
+    ) {
+        val flushForEvent = call.arguments<String>()
+
+        if (flushForEvent == null) {
+            result.error(TAG, ERROR_EMIT_EVENT_PROBLEM(flushForEvent), null)
+            return
+        }
+
+        val ctEvent = CleverTapEvent.fromName(flushForEvent)
+        if (ctEvent == CleverTapEvent.CLEVERTAP_UNKNOWN) {
+            result.error(TAG, ERROR_EMIT_EVENT_PROBLEM(flushForEvent), null)
+            return
+        }
+
+        CleverTapEventEmitter.flushBuffer(ctEvent)
+        CleverTapEventEmitter.disableBuffer(ctEvent)
+        result.success(true)
     }
 
     private fun setLocale(call: MethodCall, result: MethodChannel.Result) {
@@ -1974,7 +2004,7 @@ class DartToNativePlatformCommunicator(
             } else {
                 result.error(
                     TAG,
-                    ERROR_TEMPLATE_NAME,
+                    ERROR_TEMPLATE_NAME(templateName),
                     "For template$templateName"
                 )
             }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/EventNameMapper.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/EventNameMapper.kt
@@ -32,6 +32,7 @@ object EventNameMapper {
             CLEVERTAP_ON_VARIABLES_CHANGED_AND_NO_DOWNLOADS_PENDING -> "onVariablesChangedAndNoDownloadsPending"
             CLEVERTAP_ONCE_VARIABLES_CHANGED_AND_NO_DOWNLOADS_PENDING -> "onceVariablesChangedAndNoDownloadsPending"
             CLEVERTAP_ON_PUSH_AMP_PAYLOAD_RECEIVED -> "pushAmpPayloadReceived"
+            CLEVERTAP_UNKNOWN -> "noop"
         }
     }
 }

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -77,8 +77,7 @@ class CleverTapPlugin {
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking
-    _dartToNativeMethodChannel.invokeMethod(
-        'setLibrary', {'libName': libName, 'libVersion': libVersion});
+    _dartToNativeMethodChannel.invokeMethod('setLibrary', {'libName': libName, 'libVersion': libVersion});
     _nativeToDartMethodChannel.setMethodCallHandler(_platformCallHandler);
   }
 
@@ -215,100 +214,129 @@ class CleverTapPlugin {
     }
   }
 
+  /**
+   * Flushes any finished events on clevertap sdk side, maybe the client attaches
+   * listener at a later point and sdk has already tried to provide callback and
+   * failed
+   */
+  void invokeStartEmission(String name) {
+    _dartToNativeMethodChannel.invokeMethod('startEmission', name);
+  }
+
   void setCleverTapCustomTemplatePresentHandler(CleverTapCustomTemplatePresentHandler handler) {
-    print("CleverTapCustomTemplatePresentHandler called");
+    invokeStartEmission('CleverTapCustomTemplatePresent');
     cleverTapCustomTemplatePresentHandler = handler;
   }
   void setCleverTapCustomFunctionPresentHandler(CleverTapCustomTemplateCloseHandler handler) {
+    invokeStartEmission('CleverTapCustomFunctionPresent');
     cleverTapCustomFunctionPresentHandler = handler;
   }
   void setCleverTapCustomTemplateCloseHandler(CleverTapCustomFunctionPresentHandler handler) {
+    invokeStartEmission('CleverTapCustomTemplateClose');
     cleverTapCustomTemplateCloseHandler = handler;
   }
 
   /// Define a method to handle inApp notification dismissed
-  void setCleverTapInAppNotificationDismissedHandler(
-          CleverTapInAppNotificationDismissedHandler handler) =>
-      cleverTapInAppNotificationDismissedHandler = handler;
+  void setCleverTapInAppNotificationDismissedHandler(CleverTapInAppNotificationDismissedHandler handler) {
+    invokeStartEmission('CleverTapInAppNotificationDismissed');
+    cleverTapInAppNotificationDismissedHandler = handler;
+  }
 
   /// Only for Android - Define a method to handle inApp notification shown
-  void setCleverTapInAppNotificationShowHandler(
-          CleverTapInAppNotificationShowHandler handler) =>
-      cleverTapInAppNotificationShowHandler = handler;
+  void setCleverTapInAppNotificationShowHandler(CleverTapInAppNotificationShowHandler handler) {
+    invokeStartEmission('CleverTapInAppNotificationShowed');
+    cleverTapInAppNotificationShowHandler = handler;
+  }
 
   /// Define a method to handle inApp notification button clicked
-  void setCleverTapInAppNotificationButtonClickedHandler(
-          CleverTapInAppNotificationButtonClickedHandler handler) =>
-      cleverTapInAppNotificationButtonClickedHandler = handler;
+  void setCleverTapInAppNotificationButtonClickedHandler(CleverTapInAppNotificationButtonClickedHandler handler) {
+    invokeStartEmission('CleverTapInAppNotificationButtonTapped');
+    cleverTapInAppNotificationButtonClickedHandler = handler;
+  }
 
   /// Define a method to handle profile initialization
-  void setCleverTapProfileDidInitializeHandler(
-          CleverTapProfileDidInitializeHandler handler) =>
-      cleverTapProfileDidInitializeHandler = handler;
+  void setCleverTapProfileDidInitializeHandler(CleverTapProfileDidInitializeHandler handler) {
+    invokeStartEmission('CleverTapProfileDidInitialize');
+    cleverTapProfileDidInitializeHandler = handler;
+  }
 
   /// Define a method to handle profile sync
-  void setCleverTapProfileSyncHandler(CleverTapProfileSyncHandler handler) =>
-      cleverTapProfileSyncHandler = handler;
+  void setCleverTapProfileSyncHandler(CleverTapProfileSyncHandler handler) {
+    invokeStartEmission('CleverTapProfileSync');
+    cleverTapProfileSyncHandler = handler;
+  }
 
   /// Define a method to handle inbox initialization
-  void setCleverTapInboxDidInitializeHandler(
-          CleverTapInboxDidInitializeHandler handler) =>
-      cleverTapInboxDidInitializeHandler = handler;
+  void setCleverTapInboxDidInitializeHandler(CleverTapInboxDidInitializeHandler handler) {
+    invokeStartEmission('CleverTapInboxDidInitialize');
+    cleverTapInboxDidInitializeHandler = handler;
+  }
 
   /// Define a method to handle inbox update
-  void setCleverTapInboxMessagesDidUpdateHandler(
-          CleverTapInboxMessagesDidUpdateHandler handler) =>
-      cleverTapInboxMessagesDidUpdateHandler = handler;
+  void setCleverTapInboxMessagesDidUpdateHandler(CleverTapInboxMessagesDidUpdateHandler handler) {
+    invokeStartEmission('CleverTapInboxMessagesDidUpdate');
+    cleverTapInboxMessagesDidUpdateHandler = handler;
+  }
 
   /// Define a method to handle inbox notification button clicked
-  void setCleverTapInboxNotificationButtonClickedHandler(
-          CleverTapInboxNotificationButtonClickedHandler handler) =>
-      cleverTapInboxNotificationButtonClickedHandler = handler;
+  void setCleverTapInboxNotificationButtonClickedHandler(CleverTapInboxNotificationButtonClickedHandler handler) {
+    invokeStartEmission('CleverTapInboxMessageButtonTapped');
+    cleverTapInboxNotificationButtonClickedHandler = handler;
+  }
 
   /// Define a method to handle inbox notification message clicked
-  void setCleverTapInboxNotificationMessageClickedHandler(
-          CleverTapInboxNotificationMessageClickedHandler handler) =>
-      cleverTapInboxNotificationMessageClickedHandler = handler;
+  void setCleverTapInboxNotificationMessageClickedHandler(CleverTapInboxNotificationMessageClickedHandler handler) {
+    invokeStartEmission('CleverTapInboxMessageTapped');
+    cleverTapInboxNotificationMessageClickedHandler = handler;
+  }
 
   /// Define a method to handle Native Display Unit updates
-  void setCleverTapDisplayUnitsLoadedHandler(
-          CleverTapDisplayUnitsLoadedHandler handler) =>
-      cleverTapDisplayUnitsLoadedHandler = handler;
+  void setCleverTapDisplayUnitsLoadedHandler(CleverTapDisplayUnitsLoadedHandler handler) {
+    invokeStartEmission('CleverTapDisplayUnitsLoaded');
+    cleverTapDisplayUnitsLoadedHandler = handler;
+  }
 
   /// Define a method to handle Feature Flag updates
-  void setCleverTapFeatureFlagUpdatedHandler(
-          CleverTapFeatureFlagUpdatedHandler handler) =>
-      cleverTapFeatureFlagUpdatedHandler = handler;
+  void setCleverTapFeatureFlagUpdatedHandler(CleverTapFeatureFlagUpdatedHandler handler) {
+    invokeStartEmission('CleverTapFeatureFlagsDidUpdate');
+    cleverTapFeatureFlagUpdatedHandler = handler;
+  }
 
   /// Define a method to handle Product config initialization
-  void setCleverTapProductConfigInitializedHandler(
-          CleverTapProductConfigInitializedHandler handler) =>
-      cleverTapProductConfigInitializedHandler = handler;
+  void setCleverTapProductConfigInitializedHandler(CleverTapProductConfigInitializedHandler handler) {
+    invokeStartEmission('CleverTapProductConfigDidInitialize');
+    cleverTapProductConfigInitializedHandler = handler;
+  }
 
   /// Define a method to handle Product config fetch updates
-  void setCleverTapProductConfigFetchedHandler(
-          CleverTapProductConfigFetchedHandler handler) =>
-      cleverTapProductConfigFetchedHandler = handler;
+  void setCleverTapProductConfigFetchedHandler(CleverTapProductConfigFetchedHandler handler) {
+    invokeStartEmission('CleverTapProductConfigDidFetch');
+    cleverTapProductConfigFetchedHandler = handler;
+  }
 
   /// Define a method to handle Product config activation updates
-  void setCleverTapProductConfigActivatedHandler(
-          CleverTapProductConfigActivatedHandler handler) =>
-      cleverTapProductConfigActivatedHandler = handler;
+  void setCleverTapProductConfigActivatedHandler(CleverTapProductConfigActivatedHandler handler) {
+    invokeStartEmission('CleverTapProductConfigDidActivate');
+    cleverTapProductConfigActivatedHandler = handler;
+  }
 
   /// Define a method to handle Push Amplification payload
-  void setCleverTapPushAmpPayloadReceivedHandler(
-          CleverTapPushAmpPayloadReceivedHandler handler) =>
-      cleverTapPushAmpPayloadReceivedHandler = handler;
+  void setCleverTapPushAmpPayloadReceivedHandler(CleverTapPushAmpPayloadReceivedHandler handler) {
+    invokeStartEmission('CleverTapPushAmpPayloadReceived');
+    cleverTapPushAmpPayloadReceivedHandler = handler;
+  }
 
   /// Define a method to handle Push Clicked payload
-  void setCleverTapPushClickedPayloadReceivedHandler(
-          CleverTapPushClickedPayloadReceivedHandler handler) =>
-      cleverTapPushClickedPayloadReceivedHandler = handler;
+  void setCleverTapPushClickedPayloadReceivedHandler(CleverTapPushClickedPayloadReceivedHandler handler) {
+    invokeStartEmission('CleverTapPushNotificationClicked');
+    cleverTapPushClickedPayloadReceivedHandler = handler;
+  }
 
   /// Define a method to handle Push permission response
-  void setCleverTapPushPermissionResponseReceivedHandler(
-          CleverTapPushPermissionResponseReceivedHandler handler) =>
-      cleverTapPushPermissionResponseReceivedHandler = handler;
+  void setCleverTapPushPermissionResponseReceivedHandler(CleverTapPushPermissionResponseReceivedHandler handler) {
+    invokeStartEmission('CleverTapPushPermissionResponseReceived');
+    cleverTapPushPermissionResponseReceivedHandler = handler;
+  }
 
   /// Set a message handler function which is called when the app is in the
   /// terminated or killed state.


### PR DESCRIPTION
- flushing and disable buffer is done once the client is setting the listener
- emits event in setters to invoke dart -> native code which clears buffer flag and flushes
- adds enum entry unknown for clean code handling
- adds safety check in emitter to not send unknown events
- changes main.dart to introduce constants for startup delays
- changes order of listeners in example app just to make it more readable