### PR TITLE
[iOS]: Added buffering and flushing logic for event emitters

### DIFF
--- a/ios/Classes/CleverTapPluginPendingEvent.h
+++ b/ios/Classes/CleverTapPluginPendingEvent.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapPluginPendingEvent : NSObject
+
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) id body;
+
+- (instancetype)initWithName:(NSString *)name body:(id)body;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Background
If an event is posted before `CleverTapPlugin` starts observing, the event will be lost.
For example, if an event is sent on `AppDelegate didFinishLaunchingWithOptions` it will not be received in the Dart listener.
This currently happens with the `CleverTapProfileDidInitialize` which is also sent/posted before the events are observed.

## Implementation

- Save all events posted before `CleverTapReactPlugin` `startObserving`. 
- Use  `[CleverTapPlugin invokeEmission:event body:body];` to send the events.
- Add observable CT events triggered before the react module has loaded. Queue the events per event name.
- Send the pending/queued events once an observer/listener is registered for that event.
- Clear the pending events 5 seconds after events are observed. Those are events no one registered an observer/listener for.

## Testing
Manual

## Backwards compatible
Yes