### PR TITLE
[SDK-5048] Fixes define boolean variables default value

### DIFF
--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -1086,7 +1086,7 @@ static NSDateFormatter *dateFormatter;
     }
     if ([value isKindOfClass:[NSNumber class]]) {
         if ([self isBoolNumber:value]) {
-            return [[CleverTap sharedInstance]defineVar:name withBool:value];
+            return [[CleverTap sharedInstance]defineVar:name withBool:[value boolValue]];
         }
         return [[CleverTap sharedInstance]defineVar:name withNumber:value];
     }


### PR DESCRIPTION
## Overview
Currently while defining boolean variables with any default value, it is converted to true while passing from flutter to native iOS. To fix this used `boolValue` of the value passed when type is boolean so that NSCFBoolean value in flutter takes actual value.