### PR TITLE
task(SDK-5447) - Adds support for android v7.7.1 and iOS v7.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## CHANGE LOG
 
+Version 3.6.0 *(06 February 2026)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v7.7.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-771-december-2-2025).
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v7.4.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-742-january-14-2026).
+
+**API changes**
+* **[Android and iOS Platform]**
+  * New API: `getVariants()` - Returns a list of A/B experiment variants for the current user.
+  * Updated API: `discardInAppNotifications({bool dismissInAppIfVisible = false})` - Added optional parameter to immediately dismiss any currently visible InApp notification in addition to discarding queued notifications.
+
 Version 3.5.3 *(22 September 2025)*
 -------------------------------------------
 **What's new**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 3.5.3
+clevertap_plugin: 3.6.0
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.clevertap.clevertap_plugin'
-version = '3.5.3'
+version = '3.6.0'
 
 buildscript {
     ext.kotlin_version = "1.8.22"
@@ -62,7 +62,7 @@ android {
     dependencies {
         implementation 'androidx.core:core-ktx:1.9.0'
         testImplementation 'junit:junit:4.13.2'
-        api 'com.clevertap.android:clevertap-android-sdk:7.5.2'
+        api 'com.clevertap.android:clevertap-android-sdk:7.7.1'
         compileOnly 'androidx.fragment:fragment:1.3.6'
         compileOnly 'androidx.core:core:1.9.0'
     }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
@@ -361,7 +361,11 @@ class DartToNativePlatformCommunicator(
             }
 
             "discardInAppNotifications" -> {
-                discardInAppNotifications(result)
+                discardInAppNotifications(call, result)
+            }
+
+            "getVariants" -> {
+                getVariants(result)
             }
 
             "resumeInAppNotifications" -> {
@@ -1483,10 +1487,19 @@ class DartToNativePlatformCommunicator(
         }
     }
 
-    private fun discardInAppNotifications(result: MethodChannel.Result) {
+    private fun discardInAppNotifications(call: MethodCall, result: MethodChannel.Result) {
         if (cleverTapAPI != null) {
-            cleverTapAPI.discardInAppNotifications()
+            val dismissInAppIfVisible = call.argument<Boolean>("dismissInAppIfVisible") ?: false
+            cleverTapAPI.discardInAppNotifications(dismissInAppIfVisible)
             result.success(null)
+        } else {
+            result.error(TAG, ERROR_MSG, null)
+        }
+    }
+
+    private fun getVariants(result: MethodChannel.Result) {
+        if (cleverTapAPI != null) {
+            result.success(cleverTapAPI.variants())
         } else {
             result.error(TAG, ERROR_MSG, null)
         }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.clevertap_plugin_example"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform, sleep;
+import 'dart:io' show Platform;
 import 'dart:math';
 import 'package:example/notification_button.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -739,9 +739,20 @@ class _MyAppState extends State<MyApp> {
                         discardInAppNotifications,
                         "Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown after this method is called."),
                     _buildListTile(
+                        "Discard InApp (dismiss visible)",
+                        discardInAppNotificationsDismissVisible,
+                        "Discards InApp Notifications and immediately dismisses any currently visible one."),
+                    _buildListTile(
                         "Resume InApp notifications",
                         resumeInAppNotifications,
                         "Resumes display of InApp Notifications."),
+                  ]),
+                if (!kIsWeb)
+                  _buildExpansionTile("A/B Testing", [
+                    _buildListTile(
+                        "Get Variants",
+                        getVariants,
+                        "Returns the list of A/B experiment variants for the current user."),
                   ]),
                 if (!kIsWeb)
                   _buildExpansionTile("Event History", [
@@ -1678,6 +1689,24 @@ class _MyAppState extends State<MyApp> {
   void discardInAppNotifications() {
     CleverTapPlugin.discardInAppNotifications();
     showToast("InApp notification is discarded");
+  }
+
+  void discardInAppNotificationsDismissVisible() {
+    CleverTapPlugin.discardInAppNotifications(dismissInAppIfVisible: true);
+    showToast("InApp notification is discarded (visible dismissed)");
+  }
+
+  void getVariants() {
+    CleverTapPlugin.getVariants().then((variants) {
+      setState((() {
+        showToast("Variants = " + variants.toString());
+        print("Variants = " + variants.toString());
+      }));
+    }).catchError((error) {
+      setState(() {
+        print("$error");
+      });
+    });
   }
 
   void resumeInAppNotifications() {

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -164,7 +164,9 @@ static NSDateFormatter *dateFormatter;
     else if ([@"suspendInAppNotifications" isEqualToString:call.method])
         [self suspendInAppNotifications];
     else if ([@"discardInAppNotifications" isEqualToString:call.method])
-        [self discardInAppNotifications];
+        [self discardInAppNotifications:call withResult:result];
+    else if ([@"getVariants" isEqualToString:call.method])
+        [self getVariants:call withResult:result];
     else if ([@"resumeInAppNotifications" isEqualToString:call.method])
         [self resumeInAppNotifications];
     else if ([@"getInboxMessageCount" isEqualToString:call.method])
@@ -645,9 +647,14 @@ static NSDateFormatter *dateFormatter;
     [[CleverTap sharedInstance] suspendInAppNotifications];
 }
 
-- (void)discardInAppNotifications {
-    
-    [[CleverTap sharedInstance] discardInAppNotifications];
+- (void)discardInAppNotifications:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    BOOL dismissInAppIfVisible = [call.arguments[@"dismissInAppIfVisible"] boolValue];
+    [[CleverTap sharedInstance] discardInAppNotifications:dismissInAppIfVisible];
+    result(nil);
+}
+
+- (void)getVariants:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    result([[CleverTap sharedInstance] variants]);
 }
 
 - (void)resumeInAppNotifications {

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '3.5.3'
+  s.version                  = '3.6.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '7.3.3'
+  s.dependency               'CleverTap-iOS-SDK', '7.4.2'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -80,7 +80,7 @@ class CleverTapPlugin {
   static const libName = 'Flutter';
 
   static const libVersion =
-      30503; // If the current version is X.X.X then pass as X0X0X
+      30600; // If the current version is X.X.X then pass as X0X0X
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking
@@ -1014,9 +1014,14 @@ class CleverTapPlugin {
   /// Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown
   /// after this method is called.
   /// The InApp Notifications will be displayed only once resumeInAppNotifications() is called.
-  static Future<void> discardInAppNotifications() async {
-    return await _dartToNativeMethodChannel
-        .invokeMethod('discardInAppNotifications', {});
+  ///
+  /// [dismissInAppIfVisible] - If true, any currently visible InApp notification will be
+  /// immediately dismissed in addition to discarding queued notifications. Defaults to false.
+  static Future<void> discardInAppNotifications(
+      {bool dismissInAppIfVisible = false}) async {
+    return await _dartToNativeMethodChannel.invokeMethod(
+        'discardInAppNotifications',
+        {'dismissInAppIfVisible': dismissInAppIfVisible});
   }
 
   /// Resumes display of InApp Notifications.
@@ -1028,6 +1033,14 @@ class CleverTapPlugin {
   static Future<void> resumeInAppNotifications() async {
     return await _dartToNativeMethodChannel
         .invokeMethod('resumeInAppNotifications', {});
+  }
+
+  /// Returns the list of A/B experiment variants for the current user.
+  ///
+  /// Each variant is a map containing at minimum an 'id' key with the variant's numeric ID.
+  /// Returns an empty list if no variants are active for the current user.
+  static Future<List?> getVariants() async {
+    return await _dartToNativeMethodChannel.invokeMethod('getVariants', {});
   }
 
   /// Initializes the inbox controller and sends a callback

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 3.5.3
+version: 3.6.0
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates underlying CleverTap Android/iOS SDK versions and adds/changes platform-channel APIs, which can introduce runtime behavior changes or compatibility issues in native integrations.
> 
> **Overview**
> Releases **v3.6.0** by upgrading dependencies to **CleverTap Android SDK `7.7.1`** and **CleverTap iOS SDK `7.4.2`**, with corresponding version bumps across `pubspec.yaml`, Gradle, podspec, and docs.
> 
> Adds a new cross-platform API `CleverTapPlugin.getVariants()` (wired through Android/iOS method channels) and updates `discardInAppNotifications` to accept `dismissInAppIfVisible` and forward it to native SDKs. The example app is updated to exercise these new capabilities and tweaks its Android `minSdkVersion` to follow Flutter’s configured value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d918df076cde3a1b50bef400b419c0e5cdd4ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->