### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGE LOG
 
-Version 3.7.0 *(6 February 2026)*
+### Version 3.7.0 *(6 February 2026)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**
@@ -14,13 +14,13 @@ Version 3.7.0 *(6 February 2026)*
   * New API: `getVariants()` - Returns experiment variant information for the current user for A/B testing.
   * Updates `discardInAppNotifications({bool? dismissInAppIfVisible})` - Adds optional parameter to dismiss any currently visible In-App notification in addition to discarding queued notifications.
 
-Version 3.6.0 *(3 November 2025)*
+### Version 3.6.0 *(3 November 2025)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**
   * Supports [CleverTap Android SDK v7.6.0](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-760-october-17-2025).
 
-Version 3.5.3 *(22 September 2025)*
+### Version 3.5.3 *(22 September 2025)*
 -------------------------------------------
 **What's new**
 * **[Web Platform]**
@@ -33,13 +33,13 @@ Version 3.5.3 *(22 September 2025)*
 * **[iOS Platform]**
   * Supports [CleverTap iOS SDK v7.3.3](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-733-september-11-2025).
 
-Version 3.5.2 *(28 August 2025)*
+### Version 3.5.2 *(28 August 2025)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**
   * Supports [CleverTap Android SDK v7.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-751-august-28-2025).
 
-Version 3.5.1 *(22 August 2025)*
+### Version 3.5.1 *(22 August 2025)*
 -------------------------------------------
 **What's new**
 * **[Web Platform]**
@@ -48,7 +48,7 @@ Version 3.5.1 *(22 August 2025)*
 * **[iOS Platform]**
   * Supports [CleverTap iOS SDK v7.3.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-732-august-08-2025).
 
-Version 3.5.0 *(21 July 2025)*
+### Version 3.5.0 *(21 July 2025)*
 -------------------------------------------
 * **[Android Platform]**
   * Supports [CleverTap Android SDK v7.5.0](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-750-july-11-2025).
@@ -72,7 +72,7 @@ Version 3.5.0 *(21 July 2025)*
   * Fixes a `No new templates are synced` error while syncing new custom templates.
   * Fixes a Local Push Primer crash when asking for push permission using promptForPushPermission.
 
-Version 3.4.0 *(27 June 2025)*
+### Version 3.4.0 *(27 June 2025)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**
@@ -81,7 +81,7 @@ Version 3.4.0 *(27 June 2025)*
 * **[iOS Platform]**
   * Supports [CleverTap iOS SDK v7.2.1](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-721-june-27-2025).
 
-Version 3.3.1 *(18 April 2025)*
+### Version 3.3.1 *(18 April 2025)*
 -------------------------------------------
 **What's new**
 * **[iOS Platform]**
@@ -96,7 +96,7 @@ Version 3.3.1 *(18 April 2025)*
   * Fixes app freezing issue when using await with `defineVariables()`.
   * Fixes custom in-app device orientation check.
 
-Version 3.3.0 *(28 March 2025)*
+### Version 3.3.0 *(28 March 2025)*
 -------------------------------------------
 > ⚠️ **NOTE**  
 > Please refer to [this guide](https://developer.clevertap.com/docs/clevertap-huawei-push-integration) for changed integration steps for Huawei PushProvider.
@@ -114,7 +114,7 @@ Version 3.3.0 *(28 March 2025)*
     - `setHuaweiPushToken(String value)`
   
 
-Version 3.2.0 *(3 March 2025)*
+### Version 3.2.0 *(3 March 2025)*
 -------------------------------------------
 > ⚠️ **NOTE**
 After upgrading the SDK to v3.2.0, don't downgrade in subsequent app releases. If you encounter any issues, please contact the CleverTap support team for assistance. 
@@ -128,7 +128,7 @@ After upgrading the SDK to v3.2.0, don't downgrade in subsequent app releases. I
   * Upgrades `Android Gradle Plugin (A.G.P)` to 8.6.1 as [recommended for Android 15](https://developer.android.com/about/versions/15/setup-sdk#:~:text=Update%20your%20app's%20build%20configuration,-Warning%3A%20If%20your&text=1%20or%20higher%2C%20first%20run,1.)
 
 
-Version 3.1.0 *(3 March 2025)*
+### Version 3.1.0 *(3 March 2025)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**
@@ -158,7 +158,7 @@ Version 3.1.0 *(3 March 2025)*
       - `sessionGetTotalVisits()`: Use `getUserAppLaunchCount()` instead for user-specific app launch count
       - `getEventHistory()`: Use `getUserEventLogHistory()` instead for user-specific event history
 
-Version 3.0.0 *(19 December 2024)*
+### Version 3.0.0 *(19 December 2024)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## CHANGE LOG
 
+Version 3.7.0 *(6 February 2026)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v7.7.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-771-december-2-2025).
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v7.4.2](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-742-january-14-2026).
+
+**API changes**
+* **[Android and iOS Platform]**
+  * New API: `getVariants()` - Returns experiment variant information for the current user for A/B testing.
+  * Updates `discardInAppNotifications({bool? dismissInAppIfVisible})` - Adds optional parameter to dismiss any currently visible In-App notification in addition to discarding queued notifications.
+
 Version 3.6.0 *(3 November 2025)*
 -------------------------------------------
 **What's new**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 3.6.0
+clevertap_plugin: 3.7.0
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.clevertap.clevertap_plugin'
-version = '3.6.0'
+version = '3.7.0'
 
 buildscript {
     ext.kotlin_version = "1.8.22"
@@ -62,7 +62,7 @@ android {
     dependencies {
         implementation 'androidx.core:core-ktx:1.9.0'
         testImplementation 'junit:junit:4.13.2'
-        api 'com.clevertap.android:clevertap-android-sdk:7.6.0'
+        api 'com.clevertap.android:clevertap-android-sdk:7.7.1'
         compileOnly 'androidx.fragment:fragment:1.3.6'
         compileOnly 'androidx.core:core:1.9.0'
     }

--- a/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/DartToNativePlatformCommunicator.kt
@@ -114,6 +114,10 @@ class DartToNativePlatformCommunicator(
                 setLocale(call, result)
             }
 
+            "getVariants" -> {
+                getVariants(result)
+            }
+
             "setPushToken" -> {
                 setFCMPushToken(call, result)
             }
@@ -361,7 +365,7 @@ class DartToNativePlatformCommunicator(
             }
 
             "discardInAppNotifications" -> {
-                discardInAppNotifications(result)
+                discardInAppNotifications(call, result)
             }
 
             "resumeInAppNotifications" -> {
@@ -671,6 +675,15 @@ class DartToNativePlatformCommunicator(
         if (cleverTapAPI != null) {
             cleverTapAPI.setLocale(locale)
             result.success(null)
+        } else {
+            result.error(TAG, ERROR_MSG, null)
+        }
+    }
+
+    private fun getVariants(result: MethodChannel.Result) {
+        if (cleverTapAPI != null) {
+            val variants = cleverTapAPI.variants()
+            result.success(variants)
         } else {
             result.error(TAG, ERROR_MSG, null)
         }
@@ -1483,9 +1496,14 @@ class DartToNativePlatformCommunicator(
         }
     }
 
-    private fun discardInAppNotifications(result: MethodChannel.Result) {
+    private fun discardInAppNotifications(call: MethodCall, result: MethodChannel.Result) {
         if (cleverTapAPI != null) {
-            cleverTapAPI.discardInAppNotifications()
+            val dismissInAppIfVisible = call.argument<Boolean>("dismissInAppIfVisible")
+            if (dismissInAppIfVisible != null) {
+                cleverTapAPI.discardInAppNotifications(dismissInAppIfVisible)
+            } else {
+                cleverTapAPI.discardInAppNotifications()
+            }
             result.success(null)
         } else {
             result.error(TAG, ERROR_MSG, null)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -627,6 +627,9 @@ class _MyAppState extends State<MyApp> {
                   _buildListTile(
                       'Add \'OnFileChanged\' listener for name \'folder1.fileVariable\'',
                       onFileChanged),
+                  if (!kIsWeb)
+                    _buildListTile('Get A/B Test Variants', getVariants,
+                        'Returns experiment variant information for the current user.'),
                 ]),
                 _buildExpansionTile("User Profiles", [
                   _buildListTile(
@@ -738,6 +741,10 @@ class _MyAppState extends State<MyApp> {
                         "Discard InApp notifications",
                         discardInAppNotifications,
                         "Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown after this method is called."),
+                    _buildListTile(
+                        "Discard InApp (Dismiss Visible)",
+                        discardInAppNotificationsWithDismiss,
+                        "Also dismisses any currently visible InApp notification."),
                     _buildListTile(
                         "Resume InApp notifications",
                         resumeInAppNotifications,
@@ -1680,6 +1687,12 @@ class _MyAppState extends State<MyApp> {
     showToast("InApp notification is discarded");
   }
 
+  void discardInAppNotificationsWithDismiss() {
+    CleverTapPlugin.discardInAppNotifications(dismissInAppIfVisible: true);
+    showToast("InApp notification discarded (with visible InApp dismissed)");
+    print("InApp -> discardInAppNotifications called with dismissInAppIfVisible: true");
+  }
+
   void resumeInAppNotifications() {
     CleverTapPlugin.resumeInAppNotifications();
     showToast("InApp notification is resumed");
@@ -1873,6 +1886,17 @@ class _MyAppState extends State<MyApp> {
     CleverTapPlugin.onFileValueChanged('folder1.fileVariable', (variable) {
       print("PE -> onFileValueChanged: " + variable.toString());
     });
+  }
+
+  void getVariants() async {
+    List? variants = await CleverTapPlugin.getVariants();
+    if (variants == null || variants.isEmpty) {
+      showToast("No A/B test variants found");
+      print("PE -> getVariants: No variants assigned");
+    } else {
+      showToast("${variants.length} variant(s) found, check console");
+      print("PE -> getVariants: " + variants.toString());
+    }
   }
 
   void handleDeeplink(Map<String, dynamic> notificationPayload) {

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -1580,7 +1580,7 @@ static NSDateFormatter *dateFormatter;
 
 - (void)getVariants:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSArray<NSDictionary<NSString *, id> *> *variants = [[CleverTap sharedInstance] variants];
-    result(variants ? variants : @[]);
+    result(variants);
 }
 
 #pragma mark - Custom Code Templates

--- a/ios/Classes/CleverTapPlugin.m
+++ b/ios/Classes/CleverTapPlugin.m
@@ -164,7 +164,7 @@ static NSDateFormatter *dateFormatter;
     else if ([@"suspendInAppNotifications" isEqualToString:call.method])
         [self suspendInAppNotifications];
     else if ([@"discardInAppNotifications" isEqualToString:call.method])
-        [self discardInAppNotifications];
+        [self discardInAppNotifications:call withResult:result];
     else if ([@"resumeInAppNotifications" isEqualToString:call.method])
         [self resumeInAppNotifications];
     else if ([@"getInboxMessageCount" isEqualToString:call.method])
@@ -287,6 +287,8 @@ static NSDateFormatter *dateFormatter;
         [self onValueChanged:call withResult:result];
     else if ([@"setLocale" isEqualToString:call.method])
         [self setLocale:call withResult:result];
+    else if ([@"getVariants" isEqualToString:call.method])
+        [self getVariants:call withResult:result];
     else if ([@"syncCustomTemplates" isEqualToString:call.method])
         [self syncCustomTemplates:call withResult:result];
     else if ([@"syncCustomTemplatesInProd" isEqualToString:call.method])
@@ -645,9 +647,14 @@ static NSDateFormatter *dateFormatter;
     [[CleverTap sharedInstance] suspendInAppNotifications];
 }
 
-- (void)discardInAppNotifications {
-    
-    [[CleverTap sharedInstance] discardInAppNotifications];
+- (void)discardInAppNotifications:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSNumber *dismissInAppIfVisible = call.arguments[@"dismissInAppIfVisible"];
+    if (dismissInAppIfVisible != nil) {
+        [[CleverTap sharedInstance] discardInAppNotifications:[dismissInAppIfVisible boolValue]];
+    } else {
+        [[CleverTap sharedInstance] discardInAppNotifications];
+    }
+    result(nil);
 }
 
 - (void)resumeInAppNotifications {
@@ -1569,6 +1576,11 @@ static NSDateFormatter *dateFormatter;
     NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:call.arguments];
     [[CleverTap sharedInstance] setLocale:locale];
     result(nil);
+}
+
+- (void)getVariants:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSArray<NSDictionary<NSString *, id> *> *variants = [[CleverTap sharedInstance] variants];
+    result(variants ? variants : @[]);
 }
 
 #pragma mark - Custom Code Templates

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '3.6.0'
+  s.version                  = '3.7.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '7.3.3'
+  s.dependency               'CleverTap-iOS-SDK', '7.4.2'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -80,7 +80,7 @@ class CleverTapPlugin {
   static const libName = 'Flutter';
 
   static const libVersion =
-      30600; // If the current version is X.X.X then pass as X0X0X
+      30700; // If the current version is X.X.X then pass as X0X0X
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking
@@ -1014,9 +1014,18 @@ class CleverTapPlugin {
   /// Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown
   /// after this method is called.
   /// The InApp Notifications will be displayed only once resumeInAppNotifications() is called.
-  static Future<void> discardInAppNotifications() async {
+  ///
+  /// Parameters:
+  /// - [dismissInAppIfVisible]: If true, also dismisses any currently visible InApp notification.
+  ///   If false or not provided, only queued/future InApps are discarded.
+  static Future<void> discardInAppNotifications(
+      {bool? dismissInAppIfVisible}) async {
+    final Map<String, dynamic> args = {};
+    if (dismissInAppIfVisible != null) {
+      args['dismissInAppIfVisible'] = dismissInAppIfVisible;
+    }
     return await _dartToNativeMethodChannel
-        .invokeMethod('discardInAppNotifications', {});
+        .invokeMethod('discardInAppNotifications', args);
   }
 
   /// Resumes display of InApp Notifications.
@@ -1395,6 +1404,16 @@ class CleverTapPlugin {
     String localeString = locale.toString();
     return await _dartToNativeMethodChannel.invokeMethod(
         'setLocale', localeString);
+  }
+
+  /// Returns experiment variant information for the current user.
+  ///
+  /// Each dictionary in the returned list contains details about an assigned A/B test variant,
+  /// with common keys like "name", "abTestId", and "abTestName".
+  ///
+  /// Returns: A list of variant dictionaries, or empty list if no variants are assigned.
+  static Future<List?> getVariants() async {
+    return await _dartToNativeMethodChannel.invokeMethod('getVariants', {});
   }
 
   ///Fetch Client Side In-Apps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 3.6.0
+version: 3.7.0
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new cross-platform method-channel surface area and changes native in-app discard behavior via an optional parameter, which could affect app messaging flows if misused; otherwise the changes are localized and versioned.
> 
> **Overview**
> Releases **v3.7.0**, updating plugin/package versions and bumping embedded native dependencies to **CleverTap Android SDK `7.7.1`** and **CleverTap iOS SDK `7.4.2`**.
> 
> Adds a new cross-platform API `getVariants()` (Android/iOS only) to return assigned A/B test variant info via the native SDK `variants()` call, with example app wiring.
> 
> Extends `discardInAppNotifications` to accept an optional `dismissInAppIfVisible` flag and plumbs it through Android/iOS native implementations to optionally dismiss a currently visible in-app in addition to clearing queued in-apps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e400cd70c1b79b56544f546656a7049053a133e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added getVariants API to access A/B test variants for experimentation.
  * Enhanced discardInAppNotifications with optional parameter to control in-app notification dismissal behavior.

* **Documentation**
  * Updated plugin version to 3.7.0 with documentation and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->