### PR TITLE
Release v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGE LOG
 
-### Version 3.8.0 *(28 February 2026)*
+### Version 3.8.0 *(2 March 2026)*
 -------------------------------------------
 **What's new**
 * **[Android Platform]**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## CHANGE LOG
 
+### Version 3.8.0 *(28 February 2026)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v7.8.0](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-780-january-22-2026).
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v7.5.0](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-750-february-9-2026).
+
+* **[Android and iOS Platform]**
+  * Adds support for inaction in-app notifications. This server-side feature allows triggering in-app notifications when users do not perform specific actions within a defined timeframe.
+  * Adds support for nested objects ingestion in event and profile properties, enabling more complex data structures for richer user profiling and event tracking.
+
 ### Version 3.7.0 *(6 February 2026)*
 -------------------------------------------
 **What's new**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 3.7.0
+clevertap_plugin: 3.8.0
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ```yaml
 dependencies:
-clevertap_plugin: 3.8.0
+  clevertap_plugin: 3.8.0
 ```
 
 - Run `flutter packages get` to install the SDK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.clevertap.clevertap_plugin'
-version = '3.7.0'
+version = '3.8.0'
 
 buildscript {
     ext.kotlin_version = "1.8.22"
@@ -62,7 +62,7 @@ android {
     dependencies {
         implementation 'androidx.core:core-ktx:1.9.0'
         testImplementation 'junit:junit:4.13.2'
-        api 'com.clevertap.android:clevertap-android-sdk:7.7.1'
+        api 'com.clevertap.android:clevertap-android-sdk:7.8.0'
         compileOnly 'androidx.fragment:fragment:1.3.6'
         compileOnly 'androidx.core:core:1.9.0'
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show Platform, sleep;
+import 'dart:io' show Platform;
 import 'dart:math';
 import 'package:example/notification_button.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -640,6 +640,10 @@ class _MyAppState extends State<MyApp> {
                           ["Enter Attribute Name", "Enter Attribute Value"]),
                       "Pushes/Records a user"),
                   _buildListTile(
+                      "Push User with Nested Objects",
+                      profilePushWithNestedObjects,
+                      "Sets profile properties with nested Map values (requires Android SDK 7.8.0+ / iOS SDK 7.5.0+)."),
+                  _buildListTile(
                       "Set Profile Multi Values",
                       setProfileMultiValue,
                       "Sets a multi valued user property"),
@@ -682,6 +686,10 @@ class _MyAppState extends State<MyApp> {
                       "Pushes/Records a custom event"),
                   _buildListTile("Push Charged Event", recordChargedEvent,
                       "Pushes/Records a Charged event"),
+                  _buildListTile(
+                      "Push Event with Nested Objects",
+                      recordEventWithNestedObjects,
+                      "Records an event with nested Map properties (requires Android SDK 7.8.0+ / iOS SDK 7.5.0+)."),
                 ]),
                 _buildExpansionTile("App Inbox", [
                   if (!kIsWeb)
@@ -1124,6 +1132,32 @@ class _MyAppState extends State<MyApp> {
     showToast("Raised event - Charged");
   }
 
+  void recordEventWithNestedObjects() {
+    var now = new DateTime.now();
+    var eventData = {
+      'Product Name': 'Casio Chronograph Watch',
+      'Category': 'Mens Watch',
+      'Price': 59.99,
+      'Specifications': {
+        'display': 'Analog',
+        'water_resistance': '100m',
+        'features': ['chronograph', 'alarm', 'backlight'],
+        'manufacturing_date': CleverTapPlugin.getCleverTapDate(now),
+      },
+      'Seller': {
+        'name': 'Watch World',
+        'rating': 4.5,
+        'location': {
+          'city': 'New York',
+          'country': 'US',
+        },
+      },
+    };
+    CleverTapPlugin.recordEvent("Product Viewed With Nested", eventData);
+    showToast("Raised event with nested objects, check console");
+    print("Nested Event -> Product Viewed With Nested: " + eventData.toString());
+  }
+
   void recordCustomUser(String attributeKey, String attributeValue) {
     var profile = {
       attributeKey: attributeValue,
@@ -1146,6 +1180,30 @@ class _MyAppState extends State<MyApp> {
     };
     CleverTapPlugin.profileSet(profile);
     showToast("Pushed profile " + profile.toString());
+  }
+
+  void profilePushWithNestedObjects() {
+    var now = new DateTime.now();
+    var profile = {
+      'Name': 'Jane Doe',
+      'Identity': '200',
+      'Email': 'jane@example.com',
+      'Preferences': {
+        'notifications': true,
+        'language': 'en',
+        'categories': ['sports', 'technology', 'travel'],
+        'lastUpdated': CleverTapPlugin.getCleverTapDate(now),
+      },
+      'Address': {
+        'street': '123 Main St',
+        'city': 'Austin',
+        'state': 'TX',
+        'country': 'US',
+      },
+    };
+    CleverTapPlugin.profileSet(profile);
+    showToast("Pushed profile with nested objects, check console");
+    print("Nested Profile -> profileSet: " + profile.toString());
   }
 
   void showInbox() {

--- a/ios/clevertap_plugin.podspec
+++ b/ios/clevertap_plugin.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name                     = 'clevertap_plugin'
-  s.version                  = '3.7.0'
+  s.version                  = '3.8.0'
   s.summary                  = 'CleverTap Flutter plugin.'
   s.description              = 'The CleverTap iOS SDK for App Analytics and Engagement.'                   
   s.homepage                 = 'https://github.com/CleverTap/clevertap-ios-sdk'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files             = 'Classes/**/*'
   s.public_header_files      = 'Classes/**/*.h'
   s.dependency               'Flutter'
-  s.dependency               'CleverTap-iOS-SDK', '7.4.2'
+  s.dependency               'CleverTap-iOS-SDK', '7.5.0'
   s.ios.deployment_target    = '9.0'
 end
 

--- a/lib/clevertap_plugin.dart
+++ b/lib/clevertap_plugin.dart
@@ -80,7 +80,7 @@ class CleverTapPlugin {
   static const libName = 'Flutter';
 
   static const libVersion =
-      30700; // If the current version is X.X.X then pass as X0X0X
+      30800; // If the current version is X.X.X then pass as X0X0X
 
   CleverTapPlugin._internal() {
     /// Set the CleverTap Flutter library name and the current version for version tracking

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clevertap_plugin
 description: The CleverTap Flutter SDK for Mobile Customer Engagement,Analytics and Retention solutions.
-version: 3.7.0
+version: 3.8.0
 homepage: https://github.com/CleverTap/clevertap-flutter
 
 environment:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Bumps the shipped Android/iOS native CleverTap SDK dependencies, so runtime behavior can change even though Flutter-side code changes are minimal. Main risk is integration/regression from upstream SDK updates and the newly supported nested object payloads.
> 
> **Overview**
> Updates the Flutter plugin release to `3.8.0` (including `pubspec.yaml`, Android/iOS package metadata, and `libVersion`).
> 
> Upgrades native dependencies to CleverTap Android SDK `7.8.0` and iOS SDK `7.5.0`, and updates docs/changelog to note new support for *inaction in-app notifications* and *nested object ingestion*.
> 
> Extends the example app with new actions demonstrating sending nested Map structures in `recordEvent` and `profileSet` payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1621a536301baa4f3620dfe88e34b67651ae216c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording events with nested object structures
  * Added support for pushing user profiles with nested object structures

* **Updates**
  * Upgraded Android SDK dependency to version 7.8.0
  * Upgraded iOS SDK dependency to version 7.5.0
  * Version bumped to 3.8.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->